### PR TITLE
Bugfix/mft transports

### DIFF
--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -70,6 +70,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.airavata</groupId>
+            <artifactId>mft-ftp-transport</artifactId>
+            <version>0.01-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.airavata</groupId>
             <artifactId>mft-admin</artifactId>
             <version>0.01-SNAPSHOT</version>
         </dependency>

--- a/agent/src/main/resources/application.properties
+++ b/agent/src/main/resources/application.properties
@@ -19,7 +19,7 @@ spring.main.web-application-type=NONE
 agent.id=agent0
 agent.host=localhost
 agent.user=dimuthu
-agent.supported.protocols=SCP,LOCAL
+agent.supported.protocols=SCP,LOCAL,FTP
 consul.host=localhost
 consul.port=8500
 

--- a/core/src/main/java/org/apache/airavata/mft/core/ConnectorResolver.java
+++ b/core/src/main/java/org/apache/airavata/mft/core/ConnectorResolver.java
@@ -97,6 +97,16 @@ public final class ConnectorResolver {
                         break;
                 }
                 break;
+            case "FTP":
+                switch (direction) {
+                    case "IN":
+                        className = "org.apache.airavata.mft.transport.ftp.FTPReceiver";
+                        break;
+                    case "OUT":
+                        className = "org.apache.airavata.mft.transport.ftp.FTPSender";
+                        break;
+                }
+                break;
         }
 
         if (className != null) {

--- a/core/src/main/java/org/apache/airavata/mft/core/MetadataCollectorResolver.java
+++ b/core/src/main/java/org/apache/airavata/mft/core/MetadataCollectorResolver.java
@@ -48,6 +48,9 @@ public final class MetadataCollectorResolver {
             case "DROPBOX":
                 className = "org.apache.airavata.mft.transport.dropbox.DropboxMetadataCollector";
                 break;
+            case "FTP":
+                className = "org.apache.airavata.mft.transport.ftp.FTPMetadataCollector";
+                break;
         }
 
         if (className != null) {

--- a/services/resource-service/server/src/main/java/org/apache/airavata/mft/resource/server/backend/ResourceBackend.java
+++ b/services/resource-service/server/src/main/java/org/apache/airavata/mft/resource/server/backend/ResourceBackend.java
@@ -66,4 +66,14 @@ public interface ResourceBackend {
     public DropboxResource createDropboxResource(DropboxResourceCreateRequest request) throws Exception;
     public boolean updateDropboxResource(DropboxResourceUpdateRequest request) throws Exception;
     public boolean deleteDropboxResource(DropboxResourceDeleteRequest request) throws Exception;
+
+    Optional<FTPStorage> getFTPStorage(FTPStorageGetRequest request) throws Exception;
+    FTPStorage createFTPStorage(FTPStorageCreateRequest request) throws Exception;
+    boolean updateFTPStorage(FTPStorageUpdateRequest request) throws Exception;
+    boolean deleteFTPStorage(FTPStorageDeleteRequest request) throws Exception;
+
+    Optional<FTPResource> getFTPResource(FTPResourceGetRequest request) throws Exception;
+    FTPResource createFTPResource(FTPResourceCreateRequest request) throws Exception;
+    boolean updateFTPResource(FTPResourceUpdateRequest request) throws Exception;
+    boolean deleteFTPResource(FTPResourceDeleteRequest request) throws Exception;
 }

--- a/services/resource-service/server/src/main/java/org/apache/airavata/mft/resource/server/backend/airavata/AiravataResourceBackend.java
+++ b/services/resource-service/server/src/main/java/org/apache/airavata/mft/resource/server/backend/airavata/AiravataResourceBackend.java
@@ -270,4 +270,44 @@ public class AiravataResourceBackend implements ResourceBackend {
     public boolean deleteDropboxResource(DropboxResourceDeleteRequest request) throws Exception {
         throw new UnsupportedOperationException("Operation is not supported in backend");
     }
+
+    @Override
+    public Optional<FTPResource> getFTPResource(FTPResourceGetRequest request) {
+        throw new UnsupportedOperationException("Operation is not supported in backend");
+    }
+
+    @Override
+    public FTPResource createFTPResource(FTPResourceCreateRequest request) {
+        throw new UnsupportedOperationException("Operation is not supported in backend");
+    }
+
+    @Override
+    public boolean updateFTPResource(FTPResourceUpdateRequest request) {
+        throw new UnsupportedOperationException("Operation is not supported in backend");
+    }
+
+    @Override
+    public boolean deleteFTPResource(FTPResourceDeleteRequest request) {
+        throw new UnsupportedOperationException("Operation is not supported in backend");
+    }
+
+    @Override
+    public Optional<FTPStorage> getFTPStorage(FTPStorageGetRequest request) {
+        throw new UnsupportedOperationException("Operation is not supported in backend");
+    }
+
+    @Override
+    public FTPStorage createFTPStorage(FTPStorageCreateRequest request) {
+        throw new UnsupportedOperationException("Operation is not supported in backend");
+    }
+
+    @Override
+    public boolean updateFTPStorage(FTPStorageUpdateRequest request) {
+        throw new UnsupportedOperationException("Operation is not supported in backend");
+    }
+
+    @Override
+    public boolean deleteFTPStorage(FTPStorageDeleteRequest request) {
+        throw new UnsupportedOperationException("Operation is not supported in backend");
+    }
 }

--- a/services/resource-service/server/src/main/java/org/apache/airavata/mft/resource/server/backend/file/FileBasedResourceBackend.java
+++ b/services/resource-service/server/src/main/java/org/apache/airavata/mft/resource/server/backend/file/FileBasedResourceBackend.java
@@ -25,12 +25,14 @@ import org.json.simple.parser.JSONParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+@SuppressWarnings("unchecked")
 public class FileBasedResourceBackend implements ResourceBackend {
 
     private static final Logger logger = LoggerFactory.getLogger(FileBasedResourceBackend.class);
@@ -381,6 +383,77 @@ public class FileBasedResourceBackend implements ResourceBackend {
 
     @Override
     public boolean deleteDropboxResource(DropboxResourceDeleteRequest request) throws Exception {
+        throw new UnsupportedOperationException("Operation is not supported in backend");
+    }
+
+    @Override
+    public Optional<FTPResource> getFTPResource(FTPResourceGetRequest request) throws Exception {
+        InputStream inputStream = FileBasedResourceBackend.class.getClassLoader().getResourceAsStream("resources.json");
+
+        JSONParser jsonParser = new JSONParser();
+
+        if (inputStream == null) {
+            throw new IOException("resources file not found");
+        }
+
+        try (InputStreamReader reader = new InputStreamReader(inputStream)) {
+
+            Object obj = jsonParser.parse(reader);
+
+            JSONArray resourceList = (JSONArray) obj;
+
+            List<FTPResource> ftpResources = (List<FTPResource>) resourceList.stream()
+                    .filter(resource -> "FTP".equals(((JSONObject) resource).get("type").toString()))
+                    .map(resource -> {
+                        JSONObject r = (JSONObject) resource;
+
+                        FTPStorage storage = FTPStorage.newBuilder()
+                                .setStorageId(((JSONObject)r.get("ftpStorage")).get("storageId").toString())
+                                .setHost(((JSONObject)r.get("ftpStorage")).get("host").toString())
+                                .setPort(Integer.parseInt(((JSONObject)r.get("ftpStorage")).get("port").toString())).build();
+
+                        return FTPResource.newBuilder()
+                                .setResourcePath(r.get("resourcePath").toString())
+                                .setResourceId(r.get("resourceId").toString())
+                                .setFtpStorage(storage).build();
+                    }).collect(Collectors.toList());
+
+            return ftpResources.stream().filter(r -> request.getResourceId().equals(r.getResourceId())).findFirst();
+        }
+    }
+
+    @Override
+    public FTPResource createFTPResource(FTPResourceCreateRequest request) {
+        throw new UnsupportedOperationException("Operation is not supported in backend");
+    }
+
+    @Override
+    public boolean updateFTPResource(FTPResourceUpdateRequest request) {
+        throw new UnsupportedOperationException("Operation is not supported in backend");
+    }
+
+    @Override
+    public boolean deleteFTPResource(FTPResourceDeleteRequest request) {
+        throw new UnsupportedOperationException("Operation is not supported in backend");
+    }
+
+    @Override
+    public Optional<FTPStorage> getFTPStorage(FTPStorageGetRequest request) {
+        throw new UnsupportedOperationException("Operation is not supported in backend");
+    }
+
+    @Override
+    public FTPStorage createFTPStorage(FTPStorageCreateRequest request) {
+        throw new UnsupportedOperationException("Operation is not supported in backend");
+    }
+
+    @Override
+    public boolean updateFTPStorage(FTPStorageUpdateRequest request) {
+        throw new UnsupportedOperationException("Operation is not supported in backend");
+    }
+
+    @Override
+    public boolean deleteFTPStorage(FTPStorageDeleteRequest request) {
         throw new UnsupportedOperationException("Operation is not supported in backend");
     }
 }

--- a/services/resource-service/server/src/main/java/org/apache/airavata/mft/resource/server/backend/sql/SQLResourceBackend.java
+++ b/services/resource-service/server/src/main/java/org/apache/airavata/mft/resource/server/backend/sql/SQLResourceBackend.java
@@ -18,12 +18,8 @@
 package org.apache.airavata.mft.resource.server.backend.sql;
 
 import org.apache.airavata.mft.resource.server.backend.ResourceBackend;
-import org.apache.airavata.mft.resource.server.backend.sql.entity.LocalResourceEntity;
-import org.apache.airavata.mft.resource.server.backend.sql.entity.SCPResourceEntity;
-import org.apache.airavata.mft.resource.server.backend.sql.entity.SCPStorageEntity;
-import org.apache.airavata.mft.resource.server.backend.sql.repository.LocalResourceRepository;
-import org.apache.airavata.mft.resource.server.backend.sql.repository.SCPResourceRepository;
-import org.apache.airavata.mft.resource.server.backend.sql.repository.SCPStorageRepository;
+import org.apache.airavata.mft.resource.server.backend.sql.entity.*;
+import org.apache.airavata.mft.resource.server.backend.sql.repository.*;
 import org.apache.airavata.mft.resource.service.*;
 import org.dozer.DozerBeanMapper;
 import org.slf4j.Logger;
@@ -44,6 +40,12 @@ public class SQLResourceBackend implements ResourceBackend {
 
     @Autowired
     private LocalResourceRepository localResourceRepository;
+
+    @Autowired
+    private FTPResourceRepository ftpResourceRepository;
+
+    @Autowired
+    private FTPStorageRepository ftpStorageRepository;
 
     private DozerBeanMapper mapper = new DozerBeanMapper();
 
@@ -234,6 +236,56 @@ public class SQLResourceBackend implements ResourceBackend {
     @Override
     public boolean deleteDropboxResource(DropboxResourceDeleteRequest request) throws Exception {
         throw new UnsupportedOperationException("Operation is not supported in backend");
+    }
+
+    @Override
+    public Optional<FTPResource> getFTPResource(FTPResourceGetRequest request) {
+        Optional<FTPResourceEntity> resourceEntity = ftpResourceRepository.findByResourceId(request.getResourceId());
+
+        return resourceEntity.map(ftpResourceEntity -> mapper.map(ftpResourceEntity, FTPResource.newBuilder().getClass())
+                .setFtpStorage(mapper.map(ftpResourceEntity.getFtpStorage(), FTPStorage.newBuilder().getClass())).build());
+    }
+
+    @Override
+    public FTPResource createFTPResource(FTPResourceCreateRequest request) {
+        FTPResourceEntity savedEntity = ftpResourceRepository.save(mapper.map(request, FTPResourceEntity.class));
+        return getFTPResource(FTPResourceGetRequest.newBuilder().setResourceId(savedEntity.getResourceId()).build()).orElse(null);
+    }
+
+    @Override
+    public boolean updateFTPResource(FTPResourceUpdateRequest request) {
+        ftpResourceRepository.save(mapper.map(request, FTPResourceEntity.class));
+        return true;
+    }
+
+    @Override
+    public boolean deleteFTPResource(FTPResourceDeleteRequest request) {
+        ftpResourceRepository.deleteById(request.getResourceId());
+        return true;
+    }
+
+    @Override
+    public Optional<FTPStorage> getFTPStorage(FTPStorageGetRequest request) {
+        Optional<FTPStorageEntity> storageEty = ftpStorageRepository.findByStorageId(request.getStorageId());
+        return storageEty.map(ftpStorageEntity -> mapper.map(ftpStorageEntity, FTPStorage.newBuilder().getClass()).build());
+    }
+
+    @Override
+    public FTPStorage createFTPStorage(FTPStorageCreateRequest request) {
+        FTPStorageEntity savedEntity = ftpStorageRepository.save(mapper.map(request, FTPStorageEntity.class));
+        return mapper.map(savedEntity, FTPStorage.newBuilder().getClass()).build();
+    }
+
+    @Override
+    public boolean updateFTPStorage(FTPStorageUpdateRequest request) {
+        ftpStorageRepository.save(mapper.map(request, FTPStorageEntity.class));
+        return true;
+    }
+
+    @Override
+    public boolean deleteFTPStorage(FTPStorageDeleteRequest request) {
+        ftpResourceRepository.deleteById(request.getStorageId());
+        return true;
     }
 
 }

--- a/services/resource-service/server/src/main/java/org/apache/airavata/mft/resource/server/backend/sql/entity/FTPResourceEntity.java
+++ b/services/resource-service/server/src/main/java/org/apache/airavata/mft/resource/server/backend/sql/entity/FTPResourceEntity.java
@@ -1,0 +1,57 @@
+package org.apache.airavata.mft.resource.server.backend.sql.entity;
+
+import org.hibernate.annotations.GenericGenerator;
+
+import javax.persistence.*;
+
+@Entity
+public class FTPResourceEntity {
+
+    @Id
+    @Column(name = "FTP_RESOURCE_ID")
+    @GeneratedValue(generator = "uuid")
+    @GenericGenerator(name = "uuid", strategy = "uuid2")
+    private String resourceId;
+
+    @Column(name = "FTP_STORAGE_ID")
+    private String ftpStorageId;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "FTP_STORAGE_ID", referencedColumnName = "FTP_STORAGE_ID", nullable = false, insertable = false, updatable = false)
+    private FTPStorageEntity ftpStorage;
+
+    @Column(name = "RESOURCE_PATH")
+    private String resourcePath;
+
+    public String getResourceId() {
+        return resourceId;
+    }
+
+    public void setResourceId(String resourceId) {
+        this.resourceId = resourceId;
+    }
+
+    public String getFtpStorageId() {
+        return ftpStorageId;
+    }
+
+    public void setFtpStorageId(String ftpStorageId) {
+        this.ftpStorageId = ftpStorageId;
+    }
+
+    public FTPStorageEntity getFtpStorage() {
+        return ftpStorage;
+    }
+
+    public void setFtpStorage(FTPStorageEntity ftpStorage) {
+        this.ftpStorage = ftpStorage;
+    }
+
+    public String getResourcePath() {
+        return resourcePath;
+    }
+
+    public void setResourcePath(String resourcePath) {
+        this.resourcePath = resourcePath;
+    }
+}

--- a/services/resource-service/server/src/main/java/org/apache/airavata/mft/resource/server/backend/sql/entity/FTPStorageEntity.java
+++ b/services/resource-service/server/src/main/java/org/apache/airavata/mft/resource/server/backend/sql/entity/FTPStorageEntity.java
@@ -1,0 +1,48 @@
+package org.apache.airavata.mft.resource.server.backend.sql.entity;
+
+import org.hibernate.annotations.GenericGenerator;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Entity
+public class FTPStorageEntity {
+
+    @Id
+    @Column(name = "FTP_STORAGE_ID")
+    @GeneratedValue(generator = "uuid")
+    @GenericGenerator(name = "uuid", strategy = "uuid2")
+    private String storageId;
+
+    @Column(name = "HOST")
+    private String host;
+
+    @Column(name = "PORT")
+    private int port;
+
+    public String getStorageId() {
+        return storageId;
+    }
+
+    public void setStorageId(String storageId) {
+        this.storageId = storageId;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
+    }
+}

--- a/services/resource-service/server/src/main/java/org/apache/airavata/mft/resource/server/backend/sql/repository/FTPResourceRepository.java
+++ b/services/resource-service/server/src/main/java/org/apache/airavata/mft/resource/server/backend/sql/repository/FTPResourceRepository.java
@@ -1,0 +1,10 @@
+package org.apache.airavata.mft.resource.server.backend.sql.repository;
+
+import org.apache.airavata.mft.resource.server.backend.sql.entity.FTPResourceEntity;
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.Optional;
+
+public interface FTPResourceRepository extends CrudRepository<FTPResourceEntity, String> {
+    Optional<FTPResourceEntity> findByResourceId(String resourceId);
+}

--- a/services/resource-service/server/src/main/java/org/apache/airavata/mft/resource/server/backend/sql/repository/FTPStorageRepository.java
+++ b/services/resource-service/server/src/main/java/org/apache/airavata/mft/resource/server/backend/sql/repository/FTPStorageRepository.java
@@ -1,0 +1,10 @@
+package org.apache.airavata.mft.resource.server.backend.sql.repository;
+
+import org.apache.airavata.mft.resource.server.backend.sql.entity.FTPStorageEntity;
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.Optional;
+
+public interface FTPStorageRepository extends CrudRepository<FTPStorageEntity, String> {
+    Optional<FTPStorageEntity> findByStorageId(String storageId);
+}

--- a/services/resource-service/server/src/main/java/org/apache/airavata/mft/resource/server/handler/ResourceServiceHandler.java
+++ b/services/resource-service/server/src/main/java/org/apache/airavata/mft/resource/server/handler/ResourceServiceHandler.java
@@ -571,4 +571,139 @@ public class ResourceServiceHandler extends ResourceServiceGrpc.ResourceServiceI
                     .asRuntimeException());
         }
     }
+
+    @Override
+    public void getFTPStorage(FTPStorageGetRequest request, StreamObserver<FTPStorage> responseObserver) {
+        try {
+            this.backend.getFTPStorage(request).ifPresentOrElse(storage -> {
+                responseObserver.onNext(storage);
+                responseObserver.onCompleted();
+            }, () -> responseObserver.onError(Status.INTERNAL
+                    .withDescription("No FTP Storage with id " + request.getStorageId())
+                    .asRuntimeException()));
+        } catch (Exception e) {
+            logger.error("Failed in retrieving FTP storage with id " + request.getStorageId(), e);
+
+            responseObserver.onError(Status.INTERNAL.withCause(e)
+                    .withDescription("Failed in retrieving FTP storage with id " + request.getStorageId())
+                    .asRuntimeException());
+        }
+    }
+
+    @Override
+    public void createFTPStorage(FTPStorageCreateRequest request, StreamObserver<FTPStorage> responseObserver) {
+        try {
+            responseObserver.onNext(this.backend.createFTPStorage(request));
+            responseObserver.onCompleted();
+        } catch (Exception e) {
+            logger.error("Failed in creating the FTP storage", e);
+
+            responseObserver.onError(Status.INTERNAL.withCause(e)
+                    .withDescription("Failed in creating the FTP storage")
+                    .asRuntimeException());
+        }
+    }
+
+    @Override
+    public void updateFTPStorage(FTPStorageUpdateRequest request, StreamObserver<Empty> responseObserver) {
+        try {
+            this.backend.updateFTPStorage(request);
+            responseObserver.onCompleted();
+        } catch (Exception e) {
+            logger.error("Failed in updating the FTP storage {}", request.getStorageId(), e);
+
+            responseObserver.onError(Status.INTERNAL.withCause(e)
+                    .withDescription("Failed in updating the FTP storage")
+                    .asRuntimeException());
+        }
+    }
+
+    @Override
+    public void deleteFTPStorage(FTPStorageDeleteRequest request, StreamObserver<Empty> responseObserver) {
+        try {
+            boolean res = this.backend.deleteFTPStorage(request);
+            if (res) {
+                responseObserver.onCompleted();
+            } else {
+                logger.error("Failed to delete FTP Storage with id " + request.getStorageId());
+
+                responseObserver.onError(Status.INTERNAL
+                        .withDescription("Failed to delete FTP Storage with id " + request.getStorageId())
+                        .asRuntimeException());
+            }
+        } catch (Exception e) {
+            logger.error("Failed in deleting the FTP storage {}", request.getStorageId(), e);
+
+            responseObserver.onError(Status.INTERNAL.withCause(e)
+                    .withDescription("Failed in deleting the FTP storage")
+                    .asRuntimeException());
+        }
+    }
+
+    @Override
+    public void getFTPResource(FTPResourceGetRequest request, StreamObserver<FTPResource> responseObserver) {
+        try {
+            this.backend.getFTPResource(request).ifPresentOrElse(resource -> {
+                responseObserver.onNext(resource);
+                responseObserver.onCompleted();
+            }, () -> responseObserver.onError(Status.INTERNAL
+                    .withDescription("No FTP Resource with id " + request.getResourceId())
+                    .asRuntimeException()));
+        } catch (Exception e) {
+            logger.error("Failed in retrieving FTP resource with id {}", request.getResourceId(), e);
+
+            responseObserver.onError(Status.INTERNAL.withCause(e)
+                    .withDescription("Failed in retrieving FTP resource with id " + request.getResourceId())
+                    .asRuntimeException());
+        }
+    }
+
+    @Override
+    public void createFTPResource(FTPResourceCreateRequest request, StreamObserver<FTPResource> responseObserver) {
+        try {
+            responseObserver.onNext(this.backend.createFTPResource(request));
+            responseObserver.onCompleted();
+        } catch (Exception e) {
+            logger.error("Failed in creating the FTP resource", e);
+
+            responseObserver.onError(Status.INTERNAL.withCause(e)
+                    .withDescription("Failed in creating the FTP resource")
+                    .asRuntimeException());
+        }
+    }
+
+    @Override
+    public void updateFTPResource(FTPResourceUpdateRequest request, StreamObserver<Empty> responseObserver) {
+        try {
+            this.backend.updateFTPResource(request);
+            responseObserver.onCompleted();
+        } catch (Exception e) {
+            logger.error("Failed in updating the FTP resource {}", request.getResourceId(), e);
+
+            responseObserver.onError(Status.INTERNAL.withCause(e)
+                    .withDescription("Failed in updating the FTP resource")
+                    .asRuntimeException());
+        }
+    }
+
+    @Override
+    public void deleteFTPResource(FTPResourceDeleteRequest request, StreamObserver<Empty> responseObserver) {
+        try {
+            boolean res = this.backend.deleteFTPResource(request);
+            if (res) {
+                responseObserver.onCompleted();
+            } else {
+
+                responseObserver.onError(Status.INTERNAL
+                        .withDescription("Failed to delete FTP Resource with id " + request.getResourceId())
+                        .asRuntimeException());
+            }
+        } catch (Exception e) {
+            logger.error("Failed in deleting the scp resource {}", request.getResourceId(), e);
+
+            responseObserver.onError(Status.INTERNAL.withCause(e)
+                    .withDescription("Failed in deleting the FTP resource")
+                    .asRuntimeException());
+        }
+    }
 }

--- a/services/resource-service/server/src/main/resources/resources.json
+++ b/services/resource-service/server/src/main/resources/resources.json
@@ -59,5 +59,15 @@
     "type": "DROPBOX",
     "resourceId": "dropbox-file",
     "resourcePath": "/test.txt"
+  },
+  {
+    "type": "FTP",
+    "resourceId": "ftp-resource",
+    "resourcePath": "mft-1mb.txt",
+    "ftpStorage": {
+      "storageId": "ftp-resource",
+      "host": "ftp.dlptest.com",
+      "port": "21"
+    }
   }
 ]

--- a/services/resource-service/stub/src/main/proto/ResourceService.proto
+++ b/services/resource-service/stub/src/main/proto/ResourceService.proto
@@ -236,6 +236,60 @@ message DropboxResourceDeleteRequest {
     string resourceId = 1;
 }
 
+// FTP Storage
+
+message FTPStorage {
+    string storageId = 1;
+    string host = 2;
+    int32 port = 3;
+}
+
+message FTPStorageGetRequest {
+    string storageId = 1;
+}
+
+message FTPStorageCreateRequest {
+    string host = 1;
+    int32 port = 2;
+}
+
+message FTPStorageUpdateRequest {
+    string storageId = 1;
+    string host = 2;
+    int32 port = 3;
+}
+
+message FTPStorageDeleteRequest {
+    string storageId = 1;
+}
+
+// FTP Resource
+
+message FTPResource {
+    string resourceId = 1;
+    FTPStorage ftpStorage = 2;
+    string resourcePath = 3;
+}
+
+message FTPResourceGetRequest {
+    string resourceId = 1;
+}
+
+message FTPResourceCreateRequest {
+    string ftpStorageId = 1;
+    string resourcePath = 2;
+}
+
+message FTPResourceUpdateRequest {
+    string resourceId = 1;
+    string FTPStorageId = 2;
+    string resourcePath = 3;
+}
+
+message FTPResourceDeleteRequest {
+    string resourceId = 1;
+}
+
 service  ResourceService {
     // SCP Storage
 
@@ -441,6 +495,58 @@ service  ResourceService {
     rpc deleteDropboxResource (DropboxResourceDeleteRequest) returns (google.protobuf.Empty) {
         option (google.api.http) = {
             delete: "/v1.0/resource/dropbox"
+        };
+    }
+
+    // FTP Storage
+
+    rpc getFTPStorage (FTPStorageGetRequest) returns (FTPStorage) {
+        option (google.api.http) = {
+           get: "/v1.0/resource/ftp/storage"
+        };
+    }
+
+    rpc createFTPStorage (FTPStorageCreateRequest) returns (FTPStorage) {
+        option (google.api.http) = {
+           post: "/v1.0/resource/ftp/storage"
+        };
+    }
+
+    rpc updateFTPStorage (FTPStorageUpdateRequest) returns (google.protobuf.Empty) {
+        option (google.api.http) = {
+           put: "/v1.0/resource/ftp/storage"
+        };
+    }
+
+    rpc deleteFTPStorage (FTPStorageDeleteRequest) returns (google.protobuf.Empty) {
+        option (google.api.http) = {
+           delete: "/v1.0/resource/ftp/storage"
+        };
+    }
+
+    // FTP Resource
+
+    rpc getFTPResource (FTPResourceGetRequest) returns (FTPResource) {
+        option (google.api.http) = {
+           get: "/v1.0/resource/ftp"
+        };
+    }
+
+    rpc createFTPResource (FTPResourceCreateRequest) returns (FTPResource) {
+        option (google.api.http) = {
+           post: "/v1.0/resource/ftp"
+        };
+    }
+
+    rpc updateFTPResource (FTPResourceUpdateRequest) returns (google.protobuf.Empty) {
+        option (google.api.http) = {
+           put: "/v1.0/resource/ftp"
+        };
+    }
+
+    rpc deleteFTPResource (FTPResourceDeleteRequest) returns (google.protobuf.Empty) {
+        option (google.api.http) = {
+           delete: "/v1.0/resource/ftp"
         };
     }
 

--- a/services/secret-service/server/src/main/java/org/apache/airavata/mft/secret/server/backend/SecretBackend.java
+++ b/services/secret-service/server/src/main/java/org/apache/airavata/mft/secret/server/backend/SecretBackend.java
@@ -55,4 +55,9 @@ public interface SecretBackend {
     public DropboxSecret createDropboxSecret(DropboxSecretCreateRequest request) throws Exception;
     public boolean updateDropboxSecret(DropboxSecretUpdateRequest request) throws Exception;
     public boolean deleteDropboxSecret(DropboxSecretDeleteRequest request) throws Exception;
+
+    Optional<FTPSecret> getFTPSecret(FTPSecretGetRequest request) throws Exception;
+    FTPSecret createFTPSecret(FTPSecretCreateRequest request) throws Exception;
+    boolean updateFTPSecret(FTPSecretUpdateRequest request) throws Exception;
+    boolean deleteFTPSecret(FTPSecretDeleteRequest request) throws Exception;
 }

--- a/services/secret-service/server/src/main/java/org/apache/airavata/mft/secret/server/backend/airavata/AiravataSecretBackend.java
+++ b/services/secret-service/server/src/main/java/org/apache/airavata/mft/secret/server/backend/airavata/AiravataSecretBackend.java
@@ -180,5 +180,24 @@ public class AiravataSecretBackend implements SecretBackend {
         throw new UnsupportedOperationException("Operation is not supported in backend");
     }
 
+    @Override
+    public Optional<FTPSecret> getFTPSecret(FTPSecretGetRequest request) {
+        throw new UnsupportedOperationException("Operation is not supported in backend");
+    }
+
+    @Override
+    public FTPSecret createFTPSecret(FTPSecretCreateRequest request) {
+        throw new UnsupportedOperationException("Operation is not supported in backend");
+    }
+
+    @Override
+    public boolean updateFTPSecret(FTPSecretUpdateRequest request) {
+        throw new UnsupportedOperationException("Operation is not supported in backend");
+    }
+
+    @Override
+    public boolean deleteFTPSecret(FTPSecretDeleteRequest request) {
+        throw new UnsupportedOperationException("Operation is not supported in backend");
+    }
 
 }

--- a/services/secret-service/server/src/main/java/org/apache/airavata/mft/secret/server/backend/file/FileBasedSecretBackend.java
+++ b/services/secret-service/server/src/main/java/org/apache/airavata/mft/secret/server/backend/file/FileBasedSecretBackend.java
@@ -33,6 +33,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
+@SuppressWarnings("unchecked")
 public class FileBasedSecretBackend implements SecretBackend {
 
     private static final Logger logger = LoggerFactory.getLogger(FileBasedSecretBackend.class);
@@ -292,5 +293,46 @@ public class FileBasedSecretBackend implements SecretBackend {
         throw new UnsupportedOperationException("Operation is not supported in backend");
     }
 
+    public Optional<FTPSecret> getFTPSecret(FTPSecretGetRequest request) throws Exception {
+        JSONParser jsonParser = new JSONParser();
+        InputStream inputStream = FileBasedSecretBackend.class.getClassLoader().getResourceAsStream(secretFile);
+
+        if (inputStream == null) {
+            throw new IOException("secrets file not found");
+        }
+
+        try (InputStreamReader reader = new InputStreamReader(inputStream)) {
+            Object obj = jsonParser.parse(reader);
+            JSONArray resourceList = (JSONArray) obj;
+
+            List<FTPSecret> ftpSecrets = (List<FTPSecret>) resourceList.stream()
+                    .filter(resource -> "FTP".equals(((JSONObject) resource).get("type").toString()))
+                    .map(resource -> {
+                        JSONObject r = (JSONObject) resource;
+
+                        return FTPSecret.newBuilder()
+                                .setSecretId(r.get("secretId").toString())
+                                .setUserId(r.get("userId").toString())
+                                .setPassword(r.get("password").toString()).build();
+
+                    }).collect(Collectors.toList());
+            return ftpSecrets.stream().filter(r -> request.getSecretId().equals(r.getSecretId())).findFirst();
+        }
+    }
+
+    @Override
+    public FTPSecret createFTPSecret(FTPSecretCreateRequest request) {
+        throw new UnsupportedOperationException("Operation is not supported in backend");
+    }
+
+    @Override
+    public boolean updateFTPSecret(FTPSecretUpdateRequest request) {
+        throw new UnsupportedOperationException("Operation is not supported in backend");
+    }
+
+    @Override
+    public boolean deleteFTPSecret(FTPSecretDeleteRequest request) {
+        throw new UnsupportedOperationException("Operation is not supported in backend");
+    }
 
 }

--- a/services/secret-service/server/src/main/java/org/apache/airavata/mft/secret/server/backend/sql/SQLSecretBackend.java
+++ b/services/secret-service/server/src/main/java/org/apache/airavata/mft/secret/server/backend/sql/SQLSecretBackend.java
@@ -18,7 +18,9 @@
 package org.apache.airavata.mft.secret.server.backend.sql;
 
 import org.apache.airavata.mft.secret.server.backend.SecretBackend;
+import org.apache.airavata.mft.secret.server.backend.sql.entity.FTPSecretEntity;
 import org.apache.airavata.mft.secret.server.backend.sql.entity.SCPSecretEntity;
+import org.apache.airavata.mft.secret.server.backend.sql.repository.FTPSecretRepository;
 import org.apache.airavata.mft.secret.server.backend.sql.repository.SecretRepository;
 import org.apache.airavata.mft.secret.service.*;
 import org.dozer.DozerBeanMapper;
@@ -34,6 +36,9 @@ public class SQLSecretBackend implements SecretBackend {
 
     @Autowired
     private SecretRepository secretRepository;
+
+    @Autowired
+    private FTPSecretRepository ftpSecretRepository;
 
     private DozerBeanMapper mapper = new DozerBeanMapper();
 
@@ -171,4 +176,27 @@ public class SQLSecretBackend implements SecretBackend {
         throw new UnsupportedOperationException("Operation is not supported in backend");
     }
 
+    @Override
+    public Optional<FTPSecret> getFTPSecret(FTPSecretGetRequest request) {
+        Optional<FTPSecretEntity> secretEty = ftpSecretRepository.findBySecretId(request.getSecretId());
+        return secretEty.map(ftpSecretEntity -> mapper.map(ftpSecretEntity, FTPSecret.newBuilder().getClass()).build());
+    }
+
+    @Override
+    public FTPSecret createFTPSecret(FTPSecretCreateRequest request) {
+        FTPSecretEntity savedEntity = ftpSecretRepository.save(mapper.map(request, FTPSecretEntity.class));
+        return mapper.map(savedEntity, FTPSecret.newBuilder().getClass()).build();
+    }
+
+    @Override
+    public boolean updateFTPSecret(FTPSecretUpdateRequest request) {
+        ftpSecretRepository.save(mapper.map(request, FTPSecretEntity.class));
+        return true;
+    }
+
+    @Override
+    public boolean deleteFTPSecret(FTPSecretDeleteRequest request) {
+        ftpSecretRepository.deleteById(request.getSecretId());
+        return true;
+    }
 }

--- a/services/secret-service/server/src/main/java/org/apache/airavata/mft/secret/server/backend/sql/entity/FTPSecretEntity.java
+++ b/services/secret-service/server/src/main/java/org/apache/airavata/mft/secret/server/backend/sql/entity/FTPSecretEntity.java
@@ -1,0 +1,48 @@
+package org.apache.airavata.mft.secret.server.backend.sql.entity;
+
+import org.hibernate.annotations.GenericGenerator;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Entity
+public class FTPSecretEntity {
+
+    @Id
+    @Column(name = "SECRET_ID")
+    @GeneratedValue(generator = "uuid")
+    @GenericGenerator(name = "uuid", strategy = "uuid2")
+    private String secretId;
+
+    @Column(name = "USER_ID")
+    private String userId;
+
+    @Column(name = "PASSWORD")
+    private String password;
+
+    public String getSecretId() {
+        return secretId;
+    }
+
+    public void setSecretId(String secretId) {
+        this.secretId = secretId;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/services/secret-service/server/src/main/java/org/apache/airavata/mft/secret/server/backend/sql/repository/FTPSecretRepository.java
+++ b/services/secret-service/server/src/main/java/org/apache/airavata/mft/secret/server/backend/sql/repository/FTPSecretRepository.java
@@ -1,0 +1,10 @@
+package org.apache.airavata.mft.secret.server.backend.sql.repository;
+
+import org.apache.airavata.mft.secret.server.backend.sql.entity.FTPSecretEntity;
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.Optional;
+
+public interface FTPSecretRepository extends CrudRepository<FTPSecretEntity, String> {
+    Optional<FTPSecretEntity> findBySecretId(String secretId);
+}

--- a/services/secret-service/server/src/main/java/org/apache/airavata/mft/secret/server/handler/SecretServiceHandler.java
+++ b/services/secret-service/server/src/main/java/org/apache/airavata/mft/secret/server/handler/SecretServiceHandler.java
@@ -365,5 +365,58 @@ public class SecretServiceHandler extends SecretServiceGrpc.SecretServiceImplBas
         }
     }
 
+    @Override
+    public void getFTPSecret(FTPSecretGetRequest request, StreamObserver<FTPSecret> responseObserver) {
+        try {
+            this.backend.getFTPSecret(request).ifPresentOrElse(secret -> {
+                responseObserver.onNext(secret);
+                responseObserver.onCompleted();
+            }, () -> responseObserver.onError(Status.INTERNAL
+                    .withDescription("No FTP Secret with id " + request.getSecretId())
+                    .asRuntimeException()));
+
+        } catch (Exception e) {
+            logger.error("Error in retrieving FTP Secret with id " + request.getSecretId(), e);
+            responseObserver.onError(Status.INTERNAL.withCause(e)
+                    .withDescription("Error in retrieving FTP Secret with id " + request.getSecretId())
+                    .asRuntimeException());
+        }
+    }
+
+    @Override
+    public void createFTPSecret(FTPSecretCreateRequest request, StreamObserver<FTPSecret> responseObserver) {
+        try {
+            this.backend.createFTPSecret(request);
+        } catch (Exception e) {
+            logger.error("Error in creating FTP Secret", e);
+            responseObserver.onError(Status.INTERNAL.withCause(e)
+                    .withDescription("Error in creating FTP Secret")
+                    .asRuntimeException());
+        }
+    }
+
+    @Override
+    public void updateFTPSecret(FTPSecretUpdateRequest request, StreamObserver<Empty> responseObserver) {
+        try {
+            this.backend.updateFTPSecret(request);
+        } catch (Exception e) {
+            logger.error("Error in updating FTP Secret with id {}", request.getSecretId(), e);
+            responseObserver.onError(Status.INTERNAL.withCause(e)
+                    .withDescription("Error in updating FTP Secret with id " + request.getSecretId())
+                    .asRuntimeException());
+        }
+    }
+
+    @Override
+    public void deleteFTPSecret(FTPSecretDeleteRequest request, StreamObserver<Empty> responseObserver) {
+        try {
+            this.backend.deleteFTPSecret(request);
+        } catch (Exception e) {
+            logger.error("Error in deleting FTP Secret with id {}", request.getSecretId(), e);
+            responseObserver.onError(Status.INTERNAL.withCause(e)
+                    .withDescription("Error in deleting FTP Secret with id " + request.getSecretId())
+                    .asRuntimeException());
+        }
+    }
 
 }

--- a/services/secret-service/server/src/main/resources/secrets.json
+++ b/services/secret-service/server/src/main/resources/secrets.json
@@ -32,5 +32,11 @@
     "type": "DROPBOX",
     "secretId": "dropbox-cred",
     "accessToken": ""
+  },
+  {
+    "type": "FTP",
+    "secretId": "ftp-cred",
+    "userId": "dlpuser@dlptest.com",
+    "password": "SzMf7rTE4pCrf9dV286GuNe4N"
   }
 ]

--- a/services/secret-service/stub/src/main/proto/SecretService.proto
+++ b/services/secret-service/stub/src/main/proto/SecretService.proto
@@ -200,6 +200,36 @@ message DropboxSecretDeleteRequest {
     AuthToken authzToken = 2;
 }
 
+// FTP
+message FTPSecret {
+    string secretId = 1;
+    string userId = 2;
+    string password = 3;
+}
+
+message FTPSecretGetRequest {
+    string secretId = 1;
+    AuthToken authzToken = 2;
+}
+
+message FTPSecretCreateRequest {
+    string userId = 1;
+    string password = 2;
+    AuthToken authzToken = 3;
+}
+
+message FTPSecretUpdateRequest {
+    string secretId = 1;
+    string userId = 2;
+    string password = 3;
+    AuthToken authzToken = 4;
+}
+
+message FTPSecretDeleteRequest {
+    string secretId = 1;
+    AuthToken authzToken = 4;
+}
+
 service  SecretService {
     rpc getSCPSecret (SCPSecretGetRequest) returns (SCPSecret) {
         option (google.api.http) = {
@@ -348,6 +378,32 @@ service  SecretService {
     rpc deleteDropboxSecret (DropboxSecretDeleteRequest) returns (google.protobuf.Empty) {
         option (google.api.http) = {
             delete: "/v1.0/secret/dropbox"
+        };
+    }
+
+    // FTP
+
+    rpc getFTPSecret (FTPSecretGetRequest) returns (FTPSecret) {
+        option (google.api.http) = {
+            get: "/v1.0/secret/ftp"
+        };
+    }
+
+    rpc createFTPSecret (FTPSecretCreateRequest) returns (FTPSecret) {
+        option (google.api.http) = {
+            post: "/v1.0/secret/ftp"
+        };
+    }
+
+    rpc updateFTPSecret (FTPSecretUpdateRequest) returns (google.protobuf.Empty) {
+        option (google.api.http) = {
+            put: "/v1.0/secret/ftp"
+        };
+    }
+
+    rpc deleteFTPSecret (FTPSecretDeleteRequest) returns (google.protobuf.Empty) {
+        option (google.api.http) = {
+            delete: "/v1.0/secret/ftp"
         };
     }
 

--- a/transport/azure-transport/src/main/java/org/apache/airavata/mft/transport/azure/AzureReceiver.java
+++ b/transport/azure-transport/src/main/java/org/apache/airavata/mft/transport/azure/AzureReceiver.java
@@ -105,6 +105,7 @@ public class AzureReceiver implements Connector {
                 break;
         }
 
+        blobInputStream.close();
         streamOs.close();
         logger.info("Completed azure receive for remote server for transfer {}", context.getTransferId());
     }

--- a/transport/box-transport/src/main/java/org/apache/airavata/mft/transport/box/BoxReceiver.java
+++ b/transport/box-transport/src/main/java/org/apache/airavata/mft/transport/box/BoxReceiver.java
@@ -71,7 +71,6 @@ public class BoxReceiver implements Connector {
 
         OutputStream os = context.getStreamBuffer().getOutputStream();
         file.download(os);
-        os.flush();
         os.close();
 
         logger.info("Completed Box Receiver stream for transfer {}", context.getTransferId());

--- a/transport/ftp-transport/pom.xml
+++ b/transport/ftp-transport/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>mft-transport</artifactId>
+        <groupId>org.apache.airavata</groupId>
+        <version>0.01-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>mft-ftp-transport</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.airavata</groupId>
+            <artifactId>mft-core</artifactId>
+            <version>0.01-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-net</groupId>
+            <artifactId>commons-net</artifactId>
+            <version>3.6</version>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/transport/ftp-transport/src/main/java/org/apache/airavata/mft/transport/ftp/FTPMetadataCollector.java
+++ b/transport/ftp-transport/src/main/java/org/apache/airavata/mft/transport/ftp/FTPMetadataCollector.java
@@ -1,0 +1,106 @@
+package org.apache.airavata.mft.transport.ftp;
+
+import org.apache.airavata.mft.core.ResourceMetadata;
+import org.apache.airavata.mft.core.api.MetadataCollector;
+import org.apache.airavata.mft.resource.client.ResourceServiceClient;
+import org.apache.airavata.mft.resource.service.FTPResource;
+import org.apache.airavata.mft.resource.service.FTPResourceGetRequest;
+import org.apache.airavata.mft.resource.service.ResourceServiceGrpc;
+import org.apache.airavata.mft.secret.client.SecretServiceClient;
+import org.apache.airavata.mft.secret.service.FTPSecret;
+import org.apache.airavata.mft.secret.service.FTPSecretGetRequest;
+import org.apache.airavata.mft.secret.service.SecretServiceGrpc;
+import org.apache.commons.net.ftp.FTPClient;
+import org.apache.commons.net.ftp.FTPFile;
+import org.apache.commons.net.ftp.FTPReply;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.InputStream;
+
+public class FTPMetadataCollector implements MetadataCollector {
+
+    private static final Logger logger = LoggerFactory.getLogger(FTPMetadataCollector.class);
+
+    private String resourceServiceHost;
+    private int resourceServicePort;
+    private String secretServiceHost;
+    private int secretServicePort;
+    private boolean initialized = false;
+
+    @Override
+    public void init(String resourceServiceHost, int resourceServicePort, String secretServiceHost, int secretServicePort) {
+        this.resourceServiceHost = resourceServiceHost;
+        this.resourceServicePort = resourceServicePort;
+        this.secretServiceHost = secretServiceHost;
+        this.secretServicePort = secretServicePort;
+        this.initialized = true;
+    }
+
+    private void checkInitialized() {
+        if (!initialized) {
+            throw new IllegalStateException("FTP Metadata Collector is not initialized");
+        }
+    }
+
+    @Override
+    public ResourceMetadata getGetResourceMetadata(String resourceId, String credentialToken) {
+
+        checkInitialized();
+        ResourceServiceGrpc.ResourceServiceBlockingStub resourceClient = ResourceServiceClient.buildClient(resourceServiceHost, resourceServicePort);
+        FTPResource ftpResource = resourceClient.getFTPResource(FTPResourceGetRequest.newBuilder().setResourceId(resourceId).build());
+        SecretServiceGrpc.SecretServiceBlockingStub secretClient = SecretServiceClient.buildClient(secretServiceHost, secretServicePort);
+        FTPSecret ftpSecret = secretClient.getFTPSecret(FTPSecretGetRequest.newBuilder().setSecretId(credentialToken).build());
+
+        ResourceMetadata resourceMetadata = new ResourceMetadata();
+        FTPClient ftpClient = null;
+        try {
+            ftpClient = FTPTransportUtil.getFTPClient(ftpResource, ftpSecret);
+            logger.info("Fetching metadata for resource {} in {}", ftpResource.getResourcePath(), ftpResource.getFtpStorage().getHost());
+
+            FTPFile ftpFile = ftpClient.mlistFile(ftpResource.getResourcePath());
+
+            if (ftpFile != null) {
+                resourceMetadata.setResourceSize(ftpFile.getSize());
+                resourceMetadata.setUpdateTime(ftpFile.getTimestamp().getTimeInMillis());
+                if (ftpClient.hasFeature("MD5") && FTPReply.isPositiveCompletion(ftpClient.sendCommand("MD5 " + ftpResource.getResourcePath()))) {
+                    String[] replies = ftpClient.getReplyStrings();
+                    resourceMetadata.setMd5sum(replies[0]);
+                } else {
+                    logger.warn("MD5 fetch error out {}", ftpClient.getReplyString());
+                }
+            }
+        } catch (Exception e) {
+            logger.warn("Failed to fetch md5 for FTP resource {}", resourceId, e);
+        } finally {
+            FTPTransportUtil.disconnectFTP(ftpClient);
+        }
+
+        return resourceMetadata;
+    }
+
+    @Override
+    public Boolean isAvailable(String resourceId, String credentialToken) {
+
+        checkInitialized();
+
+        ResourceServiceGrpc.ResourceServiceBlockingStub resourceClient = ResourceServiceClient.buildClient(resourceServiceHost, resourceServicePort);
+        FTPResource ftpResource = resourceClient.getFTPResource(FTPResourceGetRequest.newBuilder().setResourceId(resourceId).build());
+        SecretServiceGrpc.SecretServiceBlockingStub secretClient = SecretServiceClient.buildClient(secretServiceHost, secretServicePort);
+        FTPSecret ftpSecret = secretClient.getFTPSecret(FTPSecretGetRequest.newBuilder().setSecretId(credentialToken).build());
+
+        FTPClient ftpClient = null;
+        try {
+            ftpClient = FTPTransportUtil.getFTPClient(ftpResource, ftpSecret);
+            InputStream inputStream = ftpClient.retrieveFileStream(ftpResource.getResourcePath());
+
+            return !(inputStream == null || ftpClient.getReplyCode() == 550);
+        } catch (Exception e) {
+            logger.error("FTP client initialization failed ", e);
+            return false;
+        } finally {
+            FTPTransportUtil.disconnectFTP(ftpClient);
+        }
+    }
+}
+

--- a/transport/ftp-transport/src/main/java/org/apache/airavata/mft/transport/ftp/FTPReceiver.java
+++ b/transport/ftp-transport/src/main/java/org/apache/airavata/mft/transport/ftp/FTPReceiver.java
@@ -1,0 +1,89 @@
+package org.apache.airavata.mft.transport.ftp;
+
+import org.apache.airavata.mft.core.ConnectorContext;
+import org.apache.airavata.mft.core.api.Connector;
+import org.apache.airavata.mft.resource.client.ResourceServiceClient;
+import org.apache.airavata.mft.resource.service.FTPResource;
+import org.apache.airavata.mft.resource.service.FTPResourceGetRequest;
+import org.apache.airavata.mft.resource.service.ResourceServiceGrpc;
+import org.apache.airavata.mft.secret.client.SecretServiceClient;
+import org.apache.airavata.mft.secret.service.FTPSecret;
+import org.apache.airavata.mft.secret.service.FTPSecretGetRequest;
+import org.apache.airavata.mft.secret.service.SecretServiceGrpc;
+import org.apache.commons.net.ftp.FTPClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public class FTPReceiver implements Connector {
+
+    private static final Logger logger = LoggerFactory.getLogger(FTPReceiver.class);
+
+    private FTPResource resource;
+    private boolean initialized;
+    private FTPClient ftpClient;
+
+    @Override
+    public void init(String resourceId, String credentialToken, String resourceServiceHost, int resourceServicePort, String secretServiceHost, int secretServicePort) throws Exception {
+        this.initialized = true;
+
+        ResourceServiceGrpc.ResourceServiceBlockingStub resourceClient = ResourceServiceClient.buildClient(resourceServiceHost, resourceServicePort);
+        this.resource = resourceClient.getFTPResource(FTPResourceGetRequest.newBuilder().setResourceId(resourceId).build());
+
+        SecretServiceGrpc.SecretServiceBlockingStub secretClient = SecretServiceClient.buildClient(secretServiceHost, secretServicePort);
+        FTPSecret ftpSecret = secretClient.getFTPSecret(FTPSecretGetRequest.newBuilder().setSecretId(credentialToken).build());
+
+        this.ftpClient = FTPTransportUtil.getFTPClient(this.resource, ftpSecret);
+    }
+
+    @Override
+    public void destroy() {
+        FTPTransportUtil.disconnectFTP(ftpClient);
+    }
+
+    @Override
+    public void startStream(ConnectorContext context) throws Exception {
+        logger.info("Starting FTP receiver stream for transfer {}", context.getTransferId());
+
+        checkInitialized();
+        OutputStream streamOs = context.getStreamBuffer().getOutputStream();
+        InputStream inputStream = ftpClient.retrieveFileStream(resource.getResourcePath());
+
+        long fileSize = context.getMetadata().getResourceSize();
+
+        byte[] buf = new byte[1024];
+        while (true) {
+            int bufSize;
+
+            if (buf.length < fileSize) {
+                bufSize = buf.length;
+            } else {
+                bufSize = (int) fileSize;
+            }
+            bufSize = inputStream.read(buf, 0, bufSize);
+
+            if (bufSize < 0) {
+                break;
+            }
+
+            streamOs.write(buf, 0, bufSize);
+            streamOs.flush();
+
+            fileSize -= bufSize;
+            if (fileSize == 0L)
+                break;
+        }
+
+        inputStream.close();
+        streamOs.close();
+        logger.info("Completed FTP receiver stream for transfer {}", context.getTransferId());
+    }
+
+    private void checkInitialized() {
+        if (!initialized) {
+            throw new IllegalStateException("FTP Receiver is not initialized");
+        }
+    }
+}

--- a/transport/ftp-transport/src/main/java/org/apache/airavata/mft/transport/ftp/FTPSender.java
+++ b/transport/ftp-transport/src/main/java/org/apache/airavata/mft/transport/ftp/FTPSender.java
@@ -1,0 +1,91 @@
+package org.apache.airavata.mft.transport.ftp;
+
+import org.apache.airavata.mft.core.ConnectorContext;
+import org.apache.airavata.mft.core.api.Connector;
+import org.apache.airavata.mft.resource.client.ResourceServiceClient;
+import org.apache.airavata.mft.resource.service.FTPResource;
+import org.apache.airavata.mft.resource.service.FTPResourceGetRequest;
+import org.apache.airavata.mft.resource.service.ResourceServiceGrpc;
+import org.apache.airavata.mft.secret.client.SecretServiceClient;
+import org.apache.airavata.mft.secret.service.FTPSecret;
+import org.apache.airavata.mft.secret.service.FTPSecretGetRequest;
+import org.apache.airavata.mft.secret.service.SecretServiceGrpc;
+import org.apache.commons.net.ftp.FTPClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public class FTPSender implements Connector {
+
+    private static final Logger logger = LoggerFactory.getLogger(FTPReceiver.class);
+
+    private FTPResource resource;
+    private boolean initialized;
+    private FTPClient ftpClient;
+
+    @Override
+    public void init(String resourceId, String credentialToken, String resourceServiceHost, int resourceServicePort, String secretServiceHost, int secretServicePort) throws Exception {
+        this.initialized = true;
+
+        ResourceServiceGrpc.ResourceServiceBlockingStub resourceClient = ResourceServiceClient.buildClient(resourceServiceHost, resourceServicePort);
+        this.resource = resourceClient.getFTPResource(FTPResourceGetRequest.newBuilder().setResourceId(resourceId).build());
+
+        SecretServiceGrpc.SecretServiceBlockingStub secretClient = SecretServiceClient.buildClient(secretServiceHost, secretServicePort);
+        FTPSecret ftpSecret = secretClient.getFTPSecret(FTPSecretGetRequest.newBuilder().setSecretId(credentialToken).build());
+
+        this.ftpClient = FTPTransportUtil.getFTPClient(this.resource, ftpSecret);
+    }
+
+    @Override
+    public void destroy() {
+        FTPTransportUtil.disconnectFTP(ftpClient);
+    }
+
+    @Override
+    public void startStream(ConnectorContext context) throws Exception {
+
+        logger.info("Starting FTP sender stream for transfer {}", context.getTransferId());
+
+        checkInitialized();
+        InputStream in = context.getStreamBuffer().getInputStream();
+        long fileSize = context.getMetadata().getResourceSize();
+        OutputStream outputStream = ftpClient.storeFileStream(resource.getResourcePath());
+
+        byte[] buf = new byte[1024];
+        while (true) {
+            int bufSize;
+
+            if (buf.length < fileSize) {
+                bufSize = buf.length;
+            } else {
+                bufSize = (int) fileSize;
+            }
+            bufSize = in.read(buf, 0, bufSize);
+
+            if (bufSize < 0) {
+                break;
+            }
+
+            outputStream.write(buf, 0, bufSize);
+            outputStream.flush();
+
+            fileSize -= bufSize;
+            if (fileSize == 0L)
+                break;
+        }
+
+        in.close();
+        outputStream.close();
+
+        logger.info("Completed FTP sender stream for transfer {}", context.getTransferId());
+
+    }
+
+    private void checkInitialized() {
+        if (!initialized) {
+            throw new IllegalStateException("FTP Sender is not initialized");
+        }
+    }
+}

--- a/transport/ftp-transport/src/main/java/org/apache/airavata/mft/transport/ftp/FTPTransportUtil.java
+++ b/transport/ftp-transport/src/main/java/org/apache/airavata/mft/transport/ftp/FTPTransportUtil.java
@@ -1,0 +1,35 @@
+package org.apache.airavata.mft.transport.ftp;
+
+import org.apache.airavata.mft.resource.service.FTPResource;
+import org.apache.airavata.mft.secret.service.FTPSecret;
+import org.apache.commons.net.ftp.FTPClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+class FTPTransportUtil {
+
+    private static final Logger logger = LoggerFactory.getLogger(FTPTransportUtil.class);
+
+    static FTPClient getFTPClient(FTPResource ftpResource, FTPSecret ftpSecret) throws IOException {
+
+        FTPClient ftpClient = new FTPClient();
+        ftpClient.connect(ftpResource.getFtpStorage().getHost(), ftpResource.getFtpStorage().getPort());
+        ftpClient.enterLocalActiveMode();
+        ftpClient.login(ftpSecret.getUserId(), ftpSecret.getPassword());
+
+        return ftpClient;
+    }
+
+    static void disconnectFTP(FTPClient ftpClient) {
+        try {
+            if (ftpClient != null) {
+                ftpClient.logout();
+                ftpClient.disconnect();
+            }
+        } catch (Exception e) {
+            logger.error("FTP client close operation failed", e);
+        }
+    }
+}

--- a/transport/gcp-transport/src/main/java/org/apache/airavata/mft/transport/gcp/GCSReceiver.java
+++ b/transport/gcp-transport/src/main/java/org/apache/airavata/mft/transport/gcp/GCSReceiver.java
@@ -80,12 +80,10 @@ public class GCSReceiver implements Connector {
 
         InputStream inputStream = storage.objects().get(this.gcsResource.getBucketName(), this.gcsResource.getResourcePath()).executeMediaAsInputStream();
         OutputStream os = context.getStreamBuffer().getOutputStream();
-        int read;
-        long bytes = 0;
         long fileSize = context.getMetadata().getResourceSize();
         byte[] buf = new byte[1024];
         while (true) {
-            int bufSize = 0;
+            int bufSize;
 
             if (buf.length < fileSize) {
                 bufSize = buf.length;
@@ -106,6 +104,7 @@ public class GCSReceiver implements Connector {
                 break;
         }
 
+        inputStream.close();
         os.close();
 
         logger.info("Completed GCS Receiver stream for transfer {}", context.getTransferId());

--- a/transport/gcp-transport/src/main/java/org/apache/airavata/mft/transport/gcp/GCSSender.java
+++ b/transport/gcp-transport/src/main/java/org/apache/airavata/mft/transport/gcp/GCSSender.java
@@ -47,6 +47,7 @@ import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 
 
 public class GCSSender implements Connector {
@@ -96,7 +97,7 @@ public class GCSSender implements Connector {
                 // Set the destination object name
                 .setName(this.gcsResource.getResourcePath())
                 // Set the access control list to publicly read-only
-                .setAcl(Arrays.asList(new ObjectAccessControl().setEntity("user-" + entityUser).setRole("OWNER")));
+                .setAcl(Collections.singletonList(new ObjectAccessControl().setEntity("user-" + entityUser).setRole("OWNER")));
 
         Insert insertRequest = storage.objects().insert(
                 this.gcsResource.getBucketName(), objectMetadata, contentStream);

--- a/transport/s3-transport/src/main/java/org/apache/airavata/mft/transport/s3/S3Receiver.java
+++ b/transport/s3-transport/src/main/java/org/apache/airavata/mft/transport/s3/S3Receiver.java
@@ -77,12 +77,11 @@ public class S3Receiver implements Connector {
 
         OutputStream os = context.getStreamBuffer().getOutputStream();
         int read;
-        long bytes = 0;
         while ((read = inputStream.read()) != -1) {
-            bytes++;
             os.write(read);
         }
-        os.flush();
+
+        inputStream.close();
         os.close();
 
         logger.info("Completed S3 Receiver stream for transfer {}", context.getTransferId());


### PR DESCRIPTION
There were streams that were not closed and redundant use of outputstream.flush()
outputstream.close() does flush internally!