### PR TITLE
Team/hogwartsrejects/unit tests

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -75,6 +75,12 @@
             <version>0.0.1-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.airavata</groupId>
+            <artifactId>mft-ftp-transport</artifactId>
+            <version>0.01-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -34,9 +34,59 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.apache.airavata</groupId>
+            <artifactId>mft-azure-transport</artifactId>
+            <version>0.01-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.airavata</groupId>
+            <artifactId>mft-box-transport</artifactId>
+            <version>0.01-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.airavata</groupId>
+            <artifactId>mft-gcp-transport</artifactId>
+            <version>0.01-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.airavata</groupId>
+            <artifactId>mft-local-transport</artifactId>
+            <version>0.01-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.airavata</groupId>
+            <artifactId>mft-s3-transport</artifactId>
+            <version>0.01-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.airavata</groupId>
+            <artifactId>mft-scp-transport</artifactId>
+            <version>0.01-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+         <dependency>
+            <groupId>org.apache.airavata</groupId>
+            <artifactId>mft-dropbox-transport</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.8.1</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.6.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/core/src/test/java/org/apache/airavata/mft/core/api/TestConnectorResolver.java
+++ b/core/src/test/java/org/apache/airavata/mft/core/api/TestConnectorResolver.java
@@ -244,7 +244,6 @@ public class TestConnectorResolver {
         }
     }
 
-    @Disabled("Writing for FTP in advance. This should start working when the code for FTP is merged with master")
     @Test
     public void testFTPIn() {
         try {
@@ -256,7 +255,6 @@ public class TestConnectorResolver {
         }
     }
 
-    @Disabled("Writing for FTP in advance. This should start working when the code for FTP is merged with master")
     @Test
     public void testFTPOut() {
         try {
@@ -268,7 +266,6 @@ public class TestConnectorResolver {
         }
     }
 
-    @Disabled("Writing for FTP in advance. This should start working when the code for FTP is merged with master")
     @Test
     public void testFTP_WrongDirection() {
         try {

--- a/core/src/test/java/org/apache/airavata/mft/core/api/TestConnectorResolver.java
+++ b/core/src/test/java/org/apache/airavata/mft/core/api/TestConnectorResolver.java
@@ -1,0 +1,281 @@
+package org.apache.airavata.mft.core.api;
+
+import org.apache.airavata.mft.core.ConnectorResolver;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TestConnectorResolver {
+
+    @Test
+    public void testOutOfScopeConnector() {
+        try {
+            Optional<Connector> connector = ConnectorResolver.resolveConnector("outOfScope", "outOfScope");
+            assertTrue(connector.isEmpty());
+        } catch(Exception ex) {
+            fail("Exception from connector: ", ex);
+        }
+    }
+
+    @Test
+    public void testSCPIn() {
+        try {
+            Optional<Connector> connector = ConnectorResolver.resolveConnector("SCP", "IN");
+            assertTrue(connector.isPresent());
+            assertEquals("org.apache.airavata.mft.transport.scp.SCPReceiver", connector.get().getClass().getCanonicalName());
+        } catch(Exception ex) {
+            fail("Exception from connector: ", ex);
+        }
+    }
+
+    @Test
+    public void testSCPOut() {
+        try {
+            Optional<Connector> connector = ConnectorResolver.resolveConnector("SCP", "OUT");
+            assertTrue(connector.isPresent());
+            assertEquals("org.apache.airavata.mft.transport.scp.SCPSender", connector.get().getClass().getCanonicalName());
+        } catch(Exception ex) {
+            fail("Exception from connector: ", ex);
+        }
+    }
+
+    @Test
+    public void testSCP_WrongDirection() {
+        try {
+            Optional<Connector> connector = ConnectorResolver.resolveConnector("SCP", "wrong input");
+            assertTrue(connector.isEmpty());
+        } catch(Exception ex) {
+            fail("Exception from connector: ", ex);
+        }
+    }
+
+    @Test
+    public void testLocalIn() {
+        try {
+            Optional<Connector> connector = ConnectorResolver.resolveConnector("LOCAL", "IN");
+            assertTrue(connector.isPresent());
+            assertEquals("org.apache.airavata.mft.transport.local.LocalReceiver", connector.get().getClass().getCanonicalName());
+        } catch(Exception ex) {
+            fail("Exception from connector: ", ex);
+        }
+    }
+
+    @Test
+    public void testLocalOut() {
+        try {
+            Optional<Connector> connector = ConnectorResolver.resolveConnector("LOCAL", "OUT");
+            assertTrue(connector.isPresent());
+            assertEquals("org.apache.airavata.mft.transport.local.LocalSender", connector.get().getClass().getCanonicalName());
+        } catch(Exception ex) {
+            fail("Exception from connector: ", ex);
+        }
+    }
+
+    @Test
+    public void testLocal_WrongDirection() {
+        try {
+            Optional<Connector> connector = ConnectorResolver.resolveConnector("LOCAL", "wrong input");
+            assertTrue(connector.isEmpty());
+        } catch(Exception ex) {
+            fail("Exception from connector: ", ex);
+        }
+    }
+
+    @Test
+    public void testS3In() {
+        try {
+            Optional<Connector> connector = ConnectorResolver.resolveConnector("S3", "IN");
+            assertTrue(connector.isPresent());
+            assertEquals("org.apache.airavata.mft.transport.s3.S3Receiver", connector.get().getClass().getCanonicalName());
+        } catch(Exception ex) {
+            fail("Exception from connector: ", ex);
+        }
+    }
+
+    @Test
+    public void testS3Out() {
+        try {
+            Optional<Connector> connector = ConnectorResolver.resolveConnector("S3", "OUT");
+            assertTrue(connector.isPresent());
+            assertEquals("org.apache.airavata.mft.transport.s3.S3Sender", connector.get().getClass().getCanonicalName());
+        } catch(Exception ex) {
+            fail("Exception from connector: ", ex);
+        }
+    }
+
+    @Test
+    public void testS3_WrongDirection() {
+        try {
+            Optional<Connector> connector = ConnectorResolver.resolveConnector("S3", "wrong input");
+            assertTrue(connector.isEmpty());
+        } catch(Exception ex) {
+            fail("Exception from connector: ", ex);
+        }
+    }
+
+    @Test
+    public void testBoxIn() {
+        try {
+            Optional<Connector> connector = ConnectorResolver.resolveConnector("BOX", "IN");
+            assertTrue(connector.isPresent());
+            assertEquals("org.apache.airavata.mft.transport.box.BoxReceiver", connector.get().getClass().getCanonicalName());
+        } catch(Exception ex) {
+            fail("Exception from connector: ", ex);
+        }
+    }
+
+    @Test
+    public void testBoxOut() {
+        try {
+            Optional<Connector> connector = ConnectorResolver.resolveConnector("BOX", "OUT");
+            assertTrue(connector.isPresent());
+            assertEquals("org.apache.airavata.mft.transport.box.BoxSender", connector.get().getClass().getCanonicalName());
+        } catch(Exception ex) {
+            fail("Exception from connector: ", ex);
+        }
+    }
+
+    @Test
+    public void testBox_WrongDirection() {
+        try {
+            Optional<Connector> connector = ConnectorResolver.resolveConnector("BOX", "wrong input");
+            assertTrue(connector.isEmpty());
+        } catch(Exception ex) {
+            fail("Exception from connector: ", ex);
+        }
+    }
+
+    @Test
+    public void testAzureIn() {
+        try {
+            Optional<Connector> connector = ConnectorResolver.resolveConnector("AZURE", "IN");
+            assertTrue(connector.isPresent());
+            assertEquals("org.apache.airavata.mft.transport.azure.AzureReceiver", connector.get().getClass().getCanonicalName());
+        } catch(Exception ex) {
+            fail("Exception from connector: ", ex);
+        }
+    }
+
+    @Test
+    public void testAzureOut() {
+        try {
+            Optional<Connector> connector = ConnectorResolver.resolveConnector("AZURE", "OUT");
+            assertTrue(connector.isPresent());
+            assertEquals("org.apache.airavata.mft.transport.azure.AzureSender", connector.get().getClass().getCanonicalName());
+        } catch(Exception ex) {
+            fail("Exception from connector: ", ex);
+        }
+    }
+
+    @Test
+    public void testAzure_WrongDirection() {
+        try {
+            Optional<Connector> connector = ConnectorResolver.resolveConnector("AZURE", "wrong input");
+            assertTrue(connector.isEmpty());
+        } catch(Exception ex) {
+            fail("Exception from connector: ", ex);
+        }
+    }
+
+    @Test
+    public void testGCSIn() {
+        try {
+            Optional<Connector> connector = ConnectorResolver.resolveConnector("GCS", "IN");
+            assertTrue(connector.isPresent());
+            assertEquals("org.apache.airavata.mft.transport.gcp.GCSReceiver", connector.get().getClass().getCanonicalName());
+        } catch(Exception ex) {
+            fail("Exception from connector: ", ex);
+        }
+    }
+
+    @Test
+    public void testGCSOut() {
+        try {
+            Optional<Connector> connector = ConnectorResolver.resolveConnector("GCS", "OUT");
+            assertTrue(connector.isPresent());
+            assertEquals("org.apache.airavata.mft.transport.gcp.GCSSender", connector.get().getClass().getCanonicalName());
+        } catch(Exception ex) {
+            fail("Exception from connector: ", ex);
+        }
+    }
+
+    @Test
+    public void testGCS_WrongDirection() {
+        try {
+            Optional<Connector> connector = ConnectorResolver.resolveConnector("GCS", "wrong input");
+            assertTrue(connector.isEmpty());
+        } catch(Exception ex) {
+            fail("Exception from connector: ", ex);
+        }
+    }
+
+    @Test
+    public void testDropboxIn() {
+        try {
+            Optional<Connector> connector = ConnectorResolver.resolveConnector("DROPBOX", "IN");
+            assertTrue(connector.isPresent());
+            assertEquals("org.apache.airavata.mft.transport.dropbox.DropboxReceiver", connector.get().getClass().getCanonicalName());
+        } catch(Exception ex) {
+            fail("Exception from connector: ", ex);
+        }
+    }
+
+    @Test
+    public void testDropboxOut() {
+        try {
+            Optional<Connector> connector = ConnectorResolver.resolveConnector("DROPBOX", "OUT");
+            assertTrue(connector.isPresent());
+            assertEquals("org.apache.airavata.mft.transport.dropbox.DropboxSender", connector.get().getClass().getCanonicalName());
+        } catch(Exception ex) {
+            fail("Exception from connector: ", ex);
+        }
+    }
+
+    @Test
+    public void testDropbox_WrongDirection() {
+        try {
+            Optional<Connector> connector = ConnectorResolver.resolveConnector("DROPBOX", "wrong input");
+            assertTrue(connector.isEmpty());
+        } catch(Exception ex) {
+            fail("Exception from connector: ", ex);
+        }
+    }
+
+    @Disabled("Writing for FTP in advance. This should start working when the code for FTP is merged with master")
+    @Test
+    public void testFTPIn() {
+        try {
+            Optional<Connector> connector = ConnectorResolver.resolveConnector("FTP", "IN");
+            assertTrue(connector.isPresent());
+            assertEquals("org.apache.airavata.mft.transport.ftp.FTPReceiver", connector.get().getClass().getCanonicalName());
+        } catch(Exception ex) {
+            fail("Exception from connector: ", ex);
+        }
+    }
+
+    @Disabled("Writing for FTP in advance. This should start working when the code for FTP is merged with master")
+    @Test
+    public void testFTPOut() {
+        try {
+            Optional<Connector> connector = ConnectorResolver.resolveConnector("FTP", "OUT");
+            assertTrue(connector.isPresent());
+            assertEquals("org.apache.airavata.mft.transport.ftp.FTPSender", connector.get().getClass().getCanonicalName());
+        } catch(Exception ex) {
+            fail("Exception from connector: ", ex);
+        }
+    }
+
+    @Disabled("Writing for FTP in advance. This should start working when the code for FTP is merged with master")
+    @Test
+    public void testFTP_WrongDirection() {
+        try {
+            Optional<Connector> connector = ConnectorResolver.resolveConnector("FTP", "wrong input");
+            assertTrue(connector.isEmpty());
+        } catch(Exception ex) {
+            fail("Exception from connector: ", ex);
+        }
+    }
+}

--- a/core/src/test/java/org/apache/airavata/mft/core/api/TestMetadataCollectorResolver.java
+++ b/core/src/test/java/org/apache/airavata/mft/core/api/TestMetadataCollectorResolver.java
@@ -1,7 +1,6 @@
 package org.apache.airavata.mft.core.api;
 
 import org.apache.airavata.mft.core.MetadataCollectorResolver;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
@@ -96,7 +95,6 @@ public class TestMetadataCollectorResolver {
         }
     }
 
-    @Disabled("Writing for FTP in advance. This should start working when the code for FTP is merged with master")
     @Test
     public void testFTP() {
         try {

--- a/core/src/test/java/org/apache/airavata/mft/core/api/TestMetadataCollectorResolver.java
+++ b/core/src/test/java/org/apache/airavata/mft/core/api/TestMetadataCollectorResolver.java
@@ -1,0 +1,110 @@
+package org.apache.airavata.mft.core.api;
+
+import org.apache.airavata.mft.core.MetadataCollectorResolver;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TestMetadataCollectorResolver {
+
+    @Test
+    public void testOutOfScopeConnector() {
+        try {
+            Optional<MetadataCollector> connector = MetadataCollectorResolver.resolveMetadataCollector("outOfScope");
+            assertTrue(connector.isEmpty());
+        } catch (Exception ex) {
+            fail("Exception from connector: ", ex);
+        }
+    }
+
+    @Test
+    public void testSCP() {
+        try {
+            Optional<MetadataCollector> connector = MetadataCollectorResolver.resolveMetadataCollector("SCP");
+            assertTrue(connector.isPresent());
+            assertEquals("org.apache.airavata.mft.transport.scp.SCPMetadataCollector", connector.get().getClass().getCanonicalName());
+        } catch (Exception ex) {
+            fail("Exception from connector: ", ex);
+        }
+    }
+
+    @Test
+    public void testLocal() {
+        try {
+            Optional<MetadataCollector> connector = MetadataCollectorResolver.resolveMetadataCollector("LOCAL");
+            assertTrue(connector.isPresent());
+            assertEquals("org.apache.airavata.mft.transport.local.LocalMetadataCollector", connector.get().getClass().getCanonicalName());
+        } catch (Exception ex) {
+            fail("Exception from connector: ", ex);
+        }
+    }
+    @Test
+    public void testS3() {
+        try {
+            Optional<MetadataCollector> connector = MetadataCollectorResolver.resolveMetadataCollector("S3");
+            assertTrue(connector.isPresent());
+            assertEquals("org.apache.airavata.mft.transport.s3.S3MetadataCollector", connector.get().getClass().getCanonicalName());
+        } catch (Exception ex) {
+            fail("Exception from connector: ", ex);
+        }
+    }
+
+    @Test
+    public void testBox() {
+        try {
+            Optional<MetadataCollector> connector = MetadataCollectorResolver.resolveMetadataCollector("BOX");
+            assertTrue(connector.isPresent());
+            assertEquals("org.apache.airavata.mft.transport.box.BoxMetadataCollector", connector.get().getClass().getCanonicalName());
+        } catch (Exception ex) {
+            fail("Exception from connector: ", ex);
+        }
+    }
+
+    @Test
+    public void testAzure() {
+        try {
+            Optional<MetadataCollector> connector = MetadataCollectorResolver.resolveMetadataCollector("AZURE");
+            assertTrue(connector.isPresent());
+            assertEquals("org.apache.airavata.mft.transport.azure.AzureMetadataCollector", connector.get().getClass().getCanonicalName());
+        } catch (Exception ex) {
+            fail("Exception from connector: ", ex);
+        }
+    }
+
+    @Test
+    public void testGCS() {
+        try {
+            Optional<MetadataCollector> connector = MetadataCollectorResolver.resolveMetadataCollector("GCS");
+            assertTrue(connector.isPresent());
+            assertEquals("org.apache.airavata.mft.transport.gcp.GCSMetadataCollector", connector.get().getClass().getCanonicalName());
+        } catch (Exception ex) {
+            fail("Exception from connector: ", ex);
+        }
+    }
+
+    @Test
+    public void testDropbox() {
+        try {
+            Optional<MetadataCollector> connector = MetadataCollectorResolver.resolveMetadataCollector("DROPBOX");
+            assertTrue(connector.isPresent());
+            assertEquals("org.apache.airavata.mft.transport.dropbox.DropboxMetadataCollector", connector.get().getClass().getCanonicalName());
+        } catch (Exception ex) {
+            fail("Exception from connector: ", ex);
+        }
+    }
+
+    @Disabled("Writing for FTP in advance. This should start working when the code for FTP is merged with master")
+    @Test
+    public void testFTP() {
+        try {
+            Optional<MetadataCollector> connector = MetadataCollectorResolver.resolveMetadataCollector("FTP");
+            assertTrue(connector.isPresent());
+            assertEquals("org.apache.airavata.mft.transport.ftp.FTPMetadataCollector", connector.get().getClass().getCanonicalName());
+        } catch (Exception ex) {
+            fail("Exception from connector: ", ex);
+        }
+    }
+}

--- a/services/resource-service/server/pom.xml
+++ b/services/resource-service/server/pom.xml
@@ -64,6 +64,19 @@
             <artifactId>grpc-services</artifactId>
             <version>1.25.0</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.6.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.3.3</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/services/resource-service/server/src/main/java/org/apache/airavata/mft/resource/server/backend/file/FileBasedResourceBackend.java
+++ b/services/resource-service/server/src/main/java/org/apache/airavata/mft/resource/server/backend/file/FileBasedResourceBackend.java
@@ -17,6 +17,7 @@
 
  package org.apache.airavata.mft.resource.server.backend.file;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.airavata.mft.resource.server.backend.ResourceBackend;
 import org.apache.airavata.mft.resource.service.*;
 import org.json.simple.JSONArray;
@@ -129,7 +130,7 @@ public class FileBasedResourceBackend implements ResourceBackend {
     @Override
     public Optional<LocalResource> getLocalResource(LocalResourceGetRequest request) throws Exception {
         JSONParser jsonParser = new JSONParser();
-        InputStream inputStream = FileBasedResourceBackend.class.getClassLoader().getResourceAsStream(resourceFile);
+        InputStream inputStream = FileBasedResourceBackend.class.getClassLoader().getResourceAsStream(getResourceFile());
 
         try (InputStreamReader reader = new InputStreamReader(inputStream)) {
             Object obj = jsonParser.parse(reader);
@@ -172,7 +173,7 @@ public class FileBasedResourceBackend implements ResourceBackend {
     @Override
     public Optional<S3Resource> getS3Resource(S3ResourceGetRequest request) throws Exception {
         JSONParser jsonParser = new JSONParser();
-        InputStream inputStream = FileBasedResourceBackend.class.getClassLoader().getResourceAsStream(resourceFile);
+        InputStream inputStream = FileBasedResourceBackend.class.getClassLoader().getResourceAsStream(getResourceFile());
 
         try (InputStreamReader reader = new InputStreamReader(inputStream)) {
             Object obj = jsonParser.parse(reader);
@@ -219,7 +220,7 @@ public class FileBasedResourceBackend implements ResourceBackend {
     @Override
     public Optional<BoxResource> getBoxResource(BoxResourceGetRequest request) throws Exception {
         JSONParser jsonParser = new JSONParser();
-        InputStream inputStream = FileBasedResourceBackend.class.getClassLoader().getResourceAsStream(resourceFile);
+        InputStream inputStream = FileBasedResourceBackend.class.getClassLoader().getResourceAsStream(getResourceFile());
 
         try (InputStreamReader reader = new InputStreamReader(inputStream)) {
             Object obj = jsonParser.parse(reader);
@@ -262,7 +263,7 @@ public class FileBasedResourceBackend implements ResourceBackend {
     @Override
     public Optional<AzureResource> getAzureResource(AzureResourceGetRequest request) throws Exception {
         JSONParser jsonParser = new JSONParser();
-        InputStream inputStream = FileBasedResourceBackend.class.getClassLoader().getResourceAsStream(resourceFile);
+        InputStream inputStream = FileBasedResourceBackend.class.getClassLoader().getResourceAsStream(getResourceFile());
 
         try (InputStreamReader reader = new InputStreamReader(inputStream)) {
             Object obj = jsonParser.parse(reader);
@@ -304,7 +305,7 @@ public class FileBasedResourceBackend implements ResourceBackend {
     @Override
     public Optional<GCSResource> getGCSResource(GCSResourceGetRequest request) throws Exception {
         JSONParser jsonParser = new JSONParser();
-        InputStream inputStream = FileBasedResourceBackend.class.getClassLoader().getResourceAsStream(resourceFile);
+        InputStream inputStream = FileBasedResourceBackend.class.getClassLoader().getResourceAsStream(getResourceFile());
 
         try (InputStreamReader reader = new InputStreamReader(inputStream)) {
             Object obj = jsonParser.parse(reader);
@@ -345,7 +346,7 @@ public class FileBasedResourceBackend implements ResourceBackend {
     @Override
     public Optional<DropboxResource> getDropboxResource(DropboxResourceGetRequest request) throws Exception {
         JSONParser jsonParser = new JSONParser();
-        InputStream inputStream = FileBasedResourceBackend.class.getClassLoader().getResourceAsStream(resourceFile);
+        InputStream inputStream = FileBasedResourceBackend.class.getClassLoader().getResourceAsStream(getResourceFile());
 
         try (InputStreamReader reader = new InputStreamReader(inputStream)) {
             Object obj = jsonParser.parse(reader);
@@ -382,5 +383,10 @@ public class FileBasedResourceBackend implements ResourceBackend {
     @Override
     public boolean deleteDropboxResource(DropboxResourceDeleteRequest request) throws Exception {
         throw new UnsupportedOperationException("Operation is not supported in backend");
+    }
+
+    @VisibleForTesting
+    protected String getResourceFile() {
+        return resourceFile;
     }
 }

--- a/services/resource-service/server/src/main/java/org/apache/airavata/mft/resource/server/backend/sql/SQLResourceBackend.java
+++ b/services/resource-service/server/src/main/java/org/apache/airavata/mft/resource/server/backend/sql/SQLResourceBackend.java
@@ -17,6 +17,7 @@
 
 package org.apache.airavata.mft.resource.server.backend.sql;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.airavata.mft.resource.server.backend.ResourceBackend;
 import org.apache.airavata.mft.resource.server.backend.sql.entity.LocalResourceEntity;
 import org.apache.airavata.mft.resource.server.backend.sql.entity.SCPResourceEntity;
@@ -59,19 +60,19 @@ public class SQLResourceBackend implements ResourceBackend {
 
     @Override
     public Optional<SCPStorage> getSCPStorage(SCPStorageGetRequest request) {
-        Optional<SCPStorageEntity> storageEty = scpStorageRepository.findByStorageId(request.getStorageId());
+        Optional<SCPStorageEntity> storageEty = getScpStorageRepository().findByStorageId(request.getStorageId());
         return storageEty.map(scpStorageEntity -> mapper.map(scpStorageEntity, SCPStorage.newBuilder().getClass()).build());
     }
 
     @Override
     public SCPStorage createSCPStorage(SCPStorageCreateRequest request) {
-        SCPStorageEntity savedEntity = scpStorageRepository.save(mapper.map(request, SCPStorageEntity.class));
+        SCPStorageEntity savedEntity = getScpStorageRepository().save(mapper.map(request, SCPStorageEntity.class));
         return mapper.map(savedEntity, SCPStorage.newBuilder().getClass()).build();
     }
 
     @Override
     public boolean updateSCPStorage(SCPStorageUpdateRequest request) {
-        SCPStorageEntity updatedEntity = scpStorageRepository.save(mapper.map(request, SCPStorageEntity.class));
+        SCPStorageEntity updatedEntity = getScpStorageRepository().save(mapper.map(request, SCPStorageEntity.class));
         return true;
     }
 
@@ -83,7 +84,7 @@ public class SQLResourceBackend implements ResourceBackend {
 
     @Override
     public Optional<SCPResource> getSCPResource(SCPResourceGetRequest request) {
-        Optional<SCPResourceEntity> resourceEntity = scpResourceRepository.findByResourceId(request.getResourceId());
+        Optional<SCPResourceEntity> resourceEntity = getScpResourceRepository().findByResourceId(request.getResourceId());
 
         return resourceEntity.map(scpResourceEntity -> mapper.map(scpResourceEntity, SCPResource.newBuilder().getClass())
                 .setScpStorage(mapper.map(scpResourceEntity.getScpStorage(), SCPStorage.newBuilder().getClass())).build());
@@ -92,43 +93,43 @@ public class SQLResourceBackend implements ResourceBackend {
 
     @Override
     public SCPResource createSCPResource(SCPResourceCreateRequest request) {
-        SCPResourceEntity savedEntity = scpResourceRepository.save(mapper.map(request, SCPResourceEntity.class));
+        SCPResourceEntity savedEntity = getScpResourceRepository().save(mapper.map(request, SCPResourceEntity.class));
         return getSCPResource(SCPResourceGetRequest.newBuilder().setResourceId(savedEntity.getResourceId()).build()).get();
     }
 
     @Override
     public boolean updateSCPResource(SCPResourceUpdateRequest request) {
-        SCPResourceEntity updatedEntity = scpResourceRepository.save(mapper.map(request, SCPResourceEntity.class));
+        SCPResourceEntity updatedEntity = getScpResourceRepository().save(mapper.map(request, SCPResourceEntity.class));
         return true;
     }
 
     @Override
     public boolean deleteSCPResource(SCPResourceDeleteRequest request) {
-        scpResourceRepository.deleteById(request.getResourceId());
+        getScpResourceRepository().deleteById(request.getResourceId());
         return true;
     }
 
     @Override
     public Optional<LocalResource> getLocalResource(LocalResourceGetRequest request) {
-        Optional<LocalResourceEntity> resourceEntity = localResourceRepository.findByResourceId(request.getResourceId());
+        Optional<LocalResourceEntity> resourceEntity = getLocalResourceRepository().findByResourceId(request.getResourceId());
         return resourceEntity.map(scpResourceEntity -> mapper.map(scpResourceEntity, LocalResource.newBuilder().getClass()).build());
     }
 
     @Override
     public LocalResource createLocalResource(LocalResourceCreateRequest request) {
-        LocalResourceEntity savedEntity = localResourceRepository.save(mapper.map(request, LocalResourceEntity.class));
+        LocalResourceEntity savedEntity = getLocalResourceRepository().save(mapper.map(request, LocalResourceEntity.class));
         return mapper.map(savedEntity, LocalResource.newBuilder().getClass()).build();
     }
 
     @Override
     public boolean updateLocalResource(LocalResourceUpdateRequest request) {
-        LocalResourceEntity updatedEntity = localResourceRepository.save(mapper.map(request, LocalResourceEntity.class));
+        LocalResourceEntity updatedEntity = getLocalResourceRepository().save(mapper.map(request, LocalResourceEntity.class));
         return true;
     }
 
     @Override
     public boolean deleteLocalResource(LocalResourceDeleteRequest request) {
-        localResourceRepository.deleteById(request.getResourceId());
+        getLocalResourceRepository().deleteById(request.getResourceId());
         return true;
     }
 
@@ -236,4 +237,18 @@ public class SQLResourceBackend implements ResourceBackend {
         throw new UnsupportedOperationException("Operation is not supported in backend");
     }
 
+    @VisibleForTesting
+    protected SCPStorageRepository getScpStorageRepository() {
+        return scpStorageRepository;
+    }
+
+    @VisibleForTesting
+    protected SCPResourceRepository getScpResourceRepository() {
+        return scpResourceRepository;
+    }
+
+    @VisibleForTesting
+    protected LocalResourceRepository getLocalResourceRepository() {
+        return localResourceRepository;
+    }
 }

--- a/services/resource-service/server/src/main/java/org/apache/airavata/mft/resource/server/handler/ResourceServiceHandler.java
+++ b/services/resource-service/server/src/main/java/org/apache/airavata/mft/resource/server/handler/ResourceServiceHandler.java
@@ -17,6 +17,7 @@
 
 package org.apache.airavata.mft.resource.server.handler;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.Empty;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
@@ -40,7 +41,7 @@ public class ResourceServiceHandler extends ResourceServiceGrpc.ResourceServiceI
     @Override
     public void getSCPStorage(SCPStorageGetRequest request, StreamObserver<SCPStorage> responseObserver) {
         try {
-            this.backend.getSCPStorage(request).ifPresentOrElse(storage -> {
+            this.getBackend().getSCPStorage(request).ifPresentOrElse(storage -> {
                 responseObserver.onNext(storage);
                 responseObserver.onCompleted();
             }, () -> {
@@ -61,7 +62,7 @@ public class ResourceServiceHandler extends ResourceServiceGrpc.ResourceServiceI
     @Override
     public void createSCPStorage(SCPStorageCreateRequest request, StreamObserver<SCPStorage> responseObserver) {
         try {
-            responseObserver.onNext(this.backend.createSCPStorage(request));
+            responseObserver.onNext(this.getBackend().createSCPStorage(request));
             responseObserver.onCompleted();
         } catch (Exception e) {
             logger.error("Failed in creating the scp storage", e);
@@ -75,7 +76,7 @@ public class ResourceServiceHandler extends ResourceServiceGrpc.ResourceServiceI
     @Override
     public void updateSCPStorage(SCPStorageUpdateRequest request, StreamObserver<Empty> responseObserver) {
         try {
-            this.backend.updateSCPStorage(request);
+            this.getBackend().updateSCPStorage(request);
             responseObserver.onCompleted();
         } catch (Exception e) {
             logger.error("Failed in updating the scp storage {}", request.getStorageId(), e);
@@ -91,7 +92,7 @@ public class ResourceServiceHandler extends ResourceServiceGrpc.ResourceServiceI
     public void deleteSCPStorage(SCPStorageDeleteRequest request, StreamObserver<Empty> responseObserver) {
 
         try {
-            boolean res = this.backend.deleteSCPStorage(request);
+            boolean res = this.getBackend().deleteSCPStorage(request);
             if (res) {
                 responseObserver.onCompleted();
             } else {
@@ -113,7 +114,7 @@ public class ResourceServiceHandler extends ResourceServiceGrpc.ResourceServiceI
     @Override
     public void getSCPResource(SCPResourceGetRequest request, StreamObserver<SCPResource> responseObserver) {
         try {
-            this.backend.getSCPResource(request).ifPresentOrElse(resource -> {
+            this.getBackend().getSCPResource(request).ifPresentOrElse(resource -> {
                 responseObserver.onNext(resource);
                 responseObserver.onCompleted();
             }, () -> {
@@ -134,7 +135,7 @@ public class ResourceServiceHandler extends ResourceServiceGrpc.ResourceServiceI
     @Override
     public void createSCPResource(SCPResourceCreateRequest request, StreamObserver<SCPResource> responseObserver) {
         try {
-            responseObserver.onNext(this.backend.createSCPResource(request));
+            responseObserver.onNext(this.getBackend().createSCPResource(request));
             responseObserver.onCompleted();
         } catch (Exception e) {
             logger.error("Failed in creating the scp resource", e);
@@ -148,7 +149,7 @@ public class ResourceServiceHandler extends ResourceServiceGrpc.ResourceServiceI
     @Override
     public void updateSCPResource(SCPResourceUpdateRequest request, StreamObserver<Empty> responseObserver) {
         try {
-            this.backend.updateSCPResource(request);
+            this.getBackend().updateSCPResource(request);
             responseObserver.onCompleted();
         } catch (Exception e) {
             logger.error("Failed in updating the scp resource {}", request.getResourceId(), e);
@@ -162,7 +163,7 @@ public class ResourceServiceHandler extends ResourceServiceGrpc.ResourceServiceI
     @Override
     public void deleteSCPResource(SCPResourceDeleteRequest request, StreamObserver<Empty> responseObserver) {
         try {
-            boolean res = this.backend.deleteSCPResource(request);
+            boolean res = this.getBackend().deleteSCPResource(request);
             if (res) {
                 responseObserver.onCompleted();
             } else {
@@ -184,7 +185,7 @@ public class ResourceServiceHandler extends ResourceServiceGrpc.ResourceServiceI
     public void getLocalResource(LocalResourceGetRequest request, StreamObserver<LocalResource> responseObserver) {
 
         try {
-            this.backend.getLocalResource(request).ifPresentOrElse(resource -> {
+            this.getBackend().getLocalResource(request).ifPresentOrElse(resource -> {
                 responseObserver.onNext(resource);
                 responseObserver.onCompleted();
             }, () -> {
@@ -204,7 +205,7 @@ public class ResourceServiceHandler extends ResourceServiceGrpc.ResourceServiceI
     @Override
     public void createLocalResource(LocalResourceCreateRequest request, StreamObserver<LocalResource> responseObserver) {
         try {
-            responseObserver.onNext(this.backend.createLocalResource(request));
+            responseObserver.onNext(this.getBackend().createLocalResource(request));
             responseObserver.onCompleted();
         } catch (Exception e) {
             logger.error("Failed in creating the local resource", e);
@@ -218,7 +219,7 @@ public class ResourceServiceHandler extends ResourceServiceGrpc.ResourceServiceI
     @Override
     public void updateLocalResource(LocalResourceUpdateRequest request, StreamObserver<Empty> responseObserver) {
         try {
-            this.backend.updateLocalResource(request);
+            this.getBackend().updateLocalResource(request);
             responseObserver.onCompleted();
         } catch (Exception e) {
             logger.error("Failed in updating the local resource {}", request.getResourceId(), e);
@@ -232,7 +233,7 @@ public class ResourceServiceHandler extends ResourceServiceGrpc.ResourceServiceI
     @Override
     public void deleteLocalResource(LocalResourceDeleteRequest request, StreamObserver<Empty> responseObserver) {
         try {
-            boolean res = this.backend.deleteLocalResource(request);
+            boolean res = this.getBackend().deleteLocalResource(request);
             if (res) {
                 responseObserver.onCompleted();
             } else {
@@ -250,7 +251,7 @@ public class ResourceServiceHandler extends ResourceServiceGrpc.ResourceServiceI
     @Override
     public void getS3Resource(S3ResourceGetRequest request, StreamObserver<S3Resource> responseObserver) {
         try {
-            this.backend.getS3Resource(request).ifPresentOrElse(resource -> {
+            this.getBackend().getS3Resource(request).ifPresentOrElse(resource -> {
                 responseObserver.onNext(resource);
                 responseObserver.onCompleted();
             }, () -> {
@@ -270,7 +271,7 @@ public class ResourceServiceHandler extends ResourceServiceGrpc.ResourceServiceI
     @Override
     public void createS3Resource(S3ResourceCreateRequest request, StreamObserver<S3Resource> responseObserver) {
         try {
-            responseObserver.onNext(this.backend.createS3Resource(request));
+            responseObserver.onNext(this.getBackend().createS3Resource(request));
             responseObserver.onCompleted();
         } catch (Exception e) {
             logger.error("Failed in creating the S3 resource", e);
@@ -284,7 +285,7 @@ public class ResourceServiceHandler extends ResourceServiceGrpc.ResourceServiceI
     @Override
     public void updateS3Resource(S3ResourceUpdateRequest request, StreamObserver<Empty> responseObserver) {
         try {
-            this.backend.updateS3Resource(request);
+            this.getBackend().updateS3Resource(request);
             responseObserver.onCompleted();
         } catch (Exception e) {
             logger.error("Failed in updating the S3 resource {}", request.getResourceId(), e);
@@ -298,7 +299,7 @@ public class ResourceServiceHandler extends ResourceServiceGrpc.ResourceServiceI
     @Override
     public void deleteS3Resource(S3ResourceDeleteRequest request, StreamObserver<Empty> responseObserver) {
         try {
-            boolean res = this.backend.deleteS3Resource(request);
+            boolean res = this.getBackend().deleteS3Resource(request);
             if (res) {
                 responseObserver.onCompleted();
             } else {
@@ -316,7 +317,7 @@ public class ResourceServiceHandler extends ResourceServiceGrpc.ResourceServiceI
     @Override
     public void getBoxResource(BoxResourceGetRequest request, StreamObserver<BoxResource> responseObserver) {
         try {
-            this.backend.getBoxResource(request).ifPresentOrElse(resource -> {
+            this.getBackend().getBoxResource(request).ifPresentOrElse(resource -> {
                 responseObserver.onNext(resource);
                 responseObserver.onCompleted();
             }, () -> {
@@ -336,7 +337,7 @@ public class ResourceServiceHandler extends ResourceServiceGrpc.ResourceServiceI
     @Override
     public void createBoxResource(BoxResourceCreateRequest request, StreamObserver<BoxResource> responseObserver) {
         try {
-            responseObserver.onNext(this.backend.createBoxResource(request));
+            responseObserver.onNext(this.getBackend().createBoxResource(request));
             responseObserver.onCompleted();
         } catch (Exception e) {
             logger.error("Failed in creating the Box resource", e);
@@ -349,7 +350,7 @@ public class ResourceServiceHandler extends ResourceServiceGrpc.ResourceServiceI
     @Override
     public void updateBoxResource(BoxResourceUpdateRequest request, StreamObserver<Empty> responseObserver) {
         try {
-            this.backend.updateBoxResource(request);
+            this.getBackend().updateBoxResource(request);
             responseObserver.onCompleted();
         } catch (Exception e) {
             logger.error("Failed in updating the Box resource {}", request.getResourceId(), e);
@@ -362,7 +363,7 @@ public class ResourceServiceHandler extends ResourceServiceGrpc.ResourceServiceI
     @Override
     public void deleteBoxResource(BoxResourceDeleteRequest request, StreamObserver<Empty> responseObserver) {
         try {
-            boolean res = this.backend.deleteBoxResource(request);
+            boolean res = this.getBackend().deleteBoxResource(request);
             if (res) {
                 responseObserver.onCompleted();
             } else {
@@ -379,7 +380,7 @@ public class ResourceServiceHandler extends ResourceServiceGrpc.ResourceServiceI
     @Override
     public void getAzureResource(AzureResourceGetRequest request, StreamObserver<AzureResource> responseObserver) {
         try {
-            this.backend.getAzureResource(request).ifPresentOrElse(resource -> {
+            this.getBackend().getAzureResource(request).ifPresentOrElse(resource -> {
                 responseObserver.onNext(resource);
                 responseObserver.onCompleted();
             }, () -> {
@@ -399,7 +400,7 @@ public class ResourceServiceHandler extends ResourceServiceGrpc.ResourceServiceI
     @Override
     public void createAzureResource(AzureResourceCreateRequest request, StreamObserver<AzureResource> responseObserver) {
         try {
-            responseObserver.onNext(this.backend.createAzureResource(request));
+            responseObserver.onNext(this.getBackend().createAzureResource(request));
             responseObserver.onCompleted();
         } catch (Exception e) {
             logger.error("Failed in creating the Azure resource", e);
@@ -413,7 +414,7 @@ public class ResourceServiceHandler extends ResourceServiceGrpc.ResourceServiceI
     @Override
     public void updateAzureResource(AzureResourceUpdateRequest request, StreamObserver<Empty> responseObserver) {
         try {
-            this.backend.updateAzureResource(request);
+            this.getBackend().updateAzureResource(request);
             responseObserver.onCompleted();
         } catch (Exception e) {
             logger.error("Failed in updating the Azure resource {}", request.getResourceId(), e);
@@ -427,7 +428,7 @@ public class ResourceServiceHandler extends ResourceServiceGrpc.ResourceServiceI
     @Override
     public void deleteAzureResource(AzureResourceDeleteRequest request, StreamObserver<Empty> responseObserver) {
         try {
-            boolean res = this.backend.deleteAzureResource(request);
+            boolean res = this.getBackend().deleteAzureResource(request);
             if (res) {
                 responseObserver.onCompleted();
             } else {
@@ -444,7 +445,7 @@ public class ResourceServiceHandler extends ResourceServiceGrpc.ResourceServiceI
     @Override
     public void getGCSResource(GCSResourceGetRequest request, StreamObserver<GCSResource> responseObserver) {
         try {
-            this.backend.getGCSResource(request).ifPresentOrElse(resource -> {
+            this.getBackend().getGCSResource(request).ifPresentOrElse(resource -> {
                 responseObserver.onNext(resource);
                 responseObserver.onCompleted();
             }, () -> {
@@ -464,7 +465,7 @@ public class ResourceServiceHandler extends ResourceServiceGrpc.ResourceServiceI
     @Override
     public void createGCSResource(GCSResourceCreateRequest request, StreamObserver<GCSResource> responseObserver) {
         try {
-            responseObserver.onNext(this.backend.createGCSResource(request));
+            responseObserver.onNext(this.getBackend().createGCSResource(request));
             responseObserver.onCompleted();
         } catch (Exception e) {
             logger.error("Failed in creating the GCS resource", e);
@@ -478,7 +479,7 @@ public class ResourceServiceHandler extends ResourceServiceGrpc.ResourceServiceI
     @Override
     public void updateGCSResource(GCSResourceUpdateRequest request, StreamObserver<Empty> responseObserver) {
         try {
-            this.backend.updateGCSResource(request);
+            this.getBackend().updateGCSResource(request);
             responseObserver.onCompleted();
         } catch (Exception e) {
             logger.error("Failed in updating the GCS resource {}", request.getResourceId(), e);
@@ -492,7 +493,7 @@ public class ResourceServiceHandler extends ResourceServiceGrpc.ResourceServiceI
     @Override
     public void deleteGCSResource(GCSResourceDeleteRequest request, StreamObserver<Empty> responseObserver) {
         try {
-            boolean res = this.backend.deleteGCSResource(request);
+            boolean res = this.getBackend().deleteGCSResource(request);
             if (res) {
                 responseObserver.onCompleted();
             } else {
@@ -509,7 +510,7 @@ public class ResourceServiceHandler extends ResourceServiceGrpc.ResourceServiceI
     @Override
     public void getDropboxResource(DropboxResourceGetRequest request, StreamObserver<DropboxResource> responseObserver) {
         try {
-            this.backend.getDropboxResource(request).ifPresentOrElse(resource -> {
+            this.getBackend().getDropboxResource(request).ifPresentOrElse(resource -> {
                 responseObserver.onNext(resource);
                 responseObserver.onCompleted();
             }, () -> {
@@ -529,7 +530,7 @@ public class ResourceServiceHandler extends ResourceServiceGrpc.ResourceServiceI
     @Override
     public void createDropboxResource(DropboxResourceCreateRequest request, StreamObserver<DropboxResource> responseObserver) {
         try {
-            responseObserver.onNext(this.backend.createDropboxResource(request));
+            responseObserver.onNext(this.getBackend().createDropboxResource(request));
             responseObserver.onCompleted();
         } catch (Exception e) {
             logger.error("Failed in creating the dropbox resource", e);
@@ -543,7 +544,7 @@ public class ResourceServiceHandler extends ResourceServiceGrpc.ResourceServiceI
     @Override
     public void updateDropboxResource(DropboxResourceUpdateRequest request, StreamObserver<Empty> responseObserver) {
         try {
-            this.backend.updateDropboxResource(request);
+            this.getBackend().updateDropboxResource(request);
             responseObserver.onCompleted();
         } catch (Exception e) {
             logger.error("Failed in updating the dropbox resource {}", request.getResourceId(), e);
@@ -557,7 +558,7 @@ public class ResourceServiceHandler extends ResourceServiceGrpc.ResourceServiceI
     @Override
     public void deleteDropboxResource(DropboxResourceDeleteRequest request, StreamObserver<Empty> responseObserver) {
         try {
-            boolean res = this.backend.deleteDropboxResource(request);
+            boolean res = this.getBackend().deleteDropboxResource(request);
             if (res) {
                 responseObserver.onCompleted();
             } else {
@@ -570,5 +571,10 @@ public class ResourceServiceHandler extends ResourceServiceGrpc.ResourceServiceI
                     .withDescription("Failed in deleting the dropbox resource with id " + request.getResourceId())
                     .asRuntimeException());
         }
+    }
+
+    @VisibleForTesting
+    protected ResourceBackend getBackend() {
+        return backend;
     }
 }

--- a/services/resource-service/server/src/test/java/org/apache/airavata/mft/resource/server/backend/file/TestFileBasedResourceBackend.java
+++ b/services/resource-service/server/src/test/java/org/apache/airavata/mft/resource/server/backend/file/TestFileBasedResourceBackend.java
@@ -19,39 +19,37 @@ public class TestFileBasedResourceBackend {
         Mockito.doReturn("resources.json").when(fileBasedResourceBackend).getResourceFile();
     }
 
-//    @Test
-//    public void testGetFtpResource_WithProperResourceId() {
-//        FileBasedResourceBackend fileBasedResourceBackend = new FileBasedResourceBackend();
-//        String resourceId = "ftp-resource";
-//        FTPResourceGetRequest resourceGetRequest = Mockito.mock(FTPResourceGetRequest.class);
-//        Mockito.when(resourceGetRequest.getResourceId()).thenReturn(resourceId);
-//
-//        try {
-//            Optional<FTPResource> ftpResourceOptional = fileBasedResourceBackend.getFTPResource(resourceGetRequest);
-//            assertTrue(ftpResourceOptional.isPresent());
-//
-//            FTPResource ftpResource = ftpResourceOptional.get();
-//            assertEquals(resourceId, ftpResource.getResourceId());
-//            assertNotNull(ftpResource.getResourcePath());
-//            assertNotNull(ftpResource.getFtpStorage().getStorageId());
-//            assertNotNull(ftpResource.getFtpStorage().getHost());
-//        } catch (Exception e) {
-//            fail("Exception from connector: ", e);
-//        }
-//    }
-//
-//    @Test
-//    public void testGetFtpResource_WithWrongResourceId() {
-//        FileBasedResourceBackend fileBasedResourceBackend = new FileBasedResourceBackend();
-//        FTPResourceGetRequest resourceGetRequest = Mockito.mock(FTPResourceGetRequest.class);
-//        Mockito.when(resourceGetRequest.getResourceId()).thenReturn("WrongResourceId");
-//
-//        try {
-//            assertTrue(fileBasedResourceBackend.getFTPResource(resourceGetRequest).isEmpty());
-//        } catch (Exception e) {
-//            fail("Exception from connector: ", e);
-//        }
-//    }
+    @Test
+    public void testGetFtpResource_WithProperResourceId() {
+        String resourceId = "ftp-resource";
+        FTPResourceGetRequest resourceGetRequest = Mockito.mock(FTPResourceGetRequest.class);
+        Mockito.when(resourceGetRequest.getResourceId()).thenReturn(resourceId);
+
+        try {
+            Optional<FTPResource> ftpResourceOptional = fileBasedResourceBackend.getFTPResource(resourceGetRequest);
+            assertTrue(ftpResourceOptional.isPresent());
+
+            FTPResource ftpResource = ftpResourceOptional.get();
+            assertEquals(resourceId, ftpResource.getResourceId());
+            assertNotNull(ftpResource.getResourcePath());
+            assertNotNull(ftpResource.getFtpStorage().getStorageId());
+            assertNotNull(ftpResource.getFtpStorage().getHost());
+        } catch (Exception e) {
+            fail("Exception from connector: ", e);
+        }
+    }
+
+    @Test
+    public void testGetFtpResource_WithWrongResourceId() {
+        FTPResourceGetRequest resourceGetRequest = Mockito.mock(FTPResourceGetRequest.class);
+        Mockito.when(resourceGetRequest.getResourceId()).thenReturn("WrongResourceId");
+
+        try {
+            assertTrue(fileBasedResourceBackend.getFTPResource(resourceGetRequest).isEmpty());
+        } catch (Exception e) {
+            fail("Exception from connector: ", e);
+        }
+    }
 
     @Test
     public void testGetSCPResource_WithProperResourceId() {

--- a/services/resource-service/server/src/test/java/org/apache/airavata/mft/resource/server/backend/file/TestFileBasedResourceBackend.java
+++ b/services/resource-service/server/src/test/java/org/apache/airavata/mft/resource/server/backend/file/TestFileBasedResourceBackend.java
@@ -1,0 +1,273 @@
+package org.apache.airavata.mft.resource.server.backend.file;
+
+import org.apache.airavata.mft.resource.service.*;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TestFileBasedResourceBackend {
+
+    static FileBasedResourceBackend fileBasedResourceBackend;
+
+    @BeforeAll
+    public static void before() {
+        fileBasedResourceBackend = Mockito.spy(new FileBasedResourceBackend());
+        Mockito.doReturn("resources.json").when(fileBasedResourceBackend).getResourceFile();
+    }
+
+//    @Test
+//    public void testGetFtpResource_WithProperResourceId() {
+//        FileBasedResourceBackend fileBasedResourceBackend = new FileBasedResourceBackend();
+//        String resourceId = "ftp-resource";
+//        FTPResourceGetRequest resourceGetRequest = Mockito.mock(FTPResourceGetRequest.class);
+//        Mockito.when(resourceGetRequest.getResourceId()).thenReturn(resourceId);
+//
+//        try {
+//            Optional<FTPResource> ftpResourceOptional = fileBasedResourceBackend.getFTPResource(resourceGetRequest);
+//            assertTrue(ftpResourceOptional.isPresent());
+//
+//            FTPResource ftpResource = ftpResourceOptional.get();
+//            assertEquals(resourceId, ftpResource.getResourceId());
+//            assertNotNull(ftpResource.getResourcePath());
+//            assertNotNull(ftpResource.getFtpStorage().getStorageId());
+//            assertNotNull(ftpResource.getFtpStorage().getHost());
+//        } catch (Exception e) {
+//            fail("Exception from connector: ", e);
+//        }
+//    }
+//
+//    @Test
+//    public void testGetFtpResource_WithWrongResourceId() {
+//        FileBasedResourceBackend fileBasedResourceBackend = new FileBasedResourceBackend();
+//        FTPResourceGetRequest resourceGetRequest = Mockito.mock(FTPResourceGetRequest.class);
+//        Mockito.when(resourceGetRequest.getResourceId()).thenReturn("WrongResourceId");
+//
+//        try {
+//            assertTrue(fileBasedResourceBackend.getFTPResource(resourceGetRequest).isEmpty());
+//        } catch (Exception e) {
+//            fail("Exception from connector: ", e);
+//        }
+//    }
+
+    @Test
+    public void testGetSCPResource_WithProperResourceId() {
+        SCPResourceGetRequest resourceGetRequest = Mockito.mock(SCPResourceGetRequest.class);
+        Mockito.when(resourceGetRequest.getResourceId()).thenReturn("WrongResourceId");
+
+        try {
+            assertTrue(fileBasedResourceBackend.getSCPResource(resourceGetRequest).isEmpty());
+        } catch (Exception e) {
+            fail("Exception from connector: ", e);
+        }
+    }
+
+    @Test
+    public void testGetSCPResource_WithWrongResourceId() {
+        String resourceId = "remote-ssh-resource";
+        SCPResourceGetRequest resourceGetRequest = Mockito.mock(SCPResourceGetRequest.class);
+        Mockito.when(resourceGetRequest.getResourceId()).thenReturn(resourceId);
+
+        try {
+            Optional<SCPResource> scpResourceOptional = fileBasedResourceBackend.getSCPResource(resourceGetRequest);
+            assertTrue(scpResourceOptional.isPresent());
+
+            SCPResource scpResource = scpResourceOptional.get();
+            assertEquals(resourceId, scpResource.getResourceId());
+            assertNotNull(scpResource.getResourcePath());
+            assertNotNull(scpResource.getScpStorage().getStorageId());
+            assertNotNull(scpResource.getScpStorage().getHost());
+            assertNotNull(scpResource.getScpStorage().getUser());
+        } catch (Exception e) {
+            fail("Exception from connector: ", e);
+        }
+    }
+
+    @Test
+    public void testGetLocalResource_WithProperResourceId() {
+        LocalResourceGetRequest resourceGetRequest = Mockito.mock(LocalResourceGetRequest.class);
+        Mockito.when(resourceGetRequest.getResourceId()).thenReturn("WrongResourceId");
+
+        try {
+            assertTrue(fileBasedResourceBackend.getLocalResource(resourceGetRequest).isEmpty());
+        } catch (Exception e) {
+            fail("Exception from connector: ", e);
+        }
+    }
+
+    @Test
+    public void testGetLocalResource_WithWrongResourceId() {
+        String resourceId = "10mb-file";
+        LocalResourceGetRequest resourceGetRequest = Mockito.mock(LocalResourceGetRequest.class);
+        Mockito.when(resourceGetRequest.getResourceId()).thenReturn(resourceId);
+
+        try {
+            Optional<LocalResource> localResourceOptional = fileBasedResourceBackend.getLocalResource(resourceGetRequest);
+            assertTrue(localResourceOptional.isPresent());
+
+            LocalResource localResource = localResourceOptional.get();
+            assertEquals(resourceId, localResource.getResourceId());
+            assertNotNull(localResource.getResourcePath());
+        } catch (Exception e) {
+            fail("Exception from connector: ", e);
+        }
+    }
+
+    @Test
+    public void testGetS3Resource_WithProperResourceId() {
+        S3ResourceGetRequest resourceGetRequest = Mockito.mock(S3ResourceGetRequest.class);
+        Mockito.when(resourceGetRequest.getResourceId()).thenReturn("WrongResourceId");
+
+        try {
+            assertTrue(fileBasedResourceBackend.getS3Resource(resourceGetRequest).isEmpty());
+        } catch (Exception e) {
+            fail("Exception from connector: ", e);
+        }
+    }
+
+    @Test
+    public void testGetS3Resource_WithWrongResourceId() {
+        String resourceId = "s3-file";
+        S3ResourceGetRequest resourceGetRequest = Mockito.mock(S3ResourceGetRequest.class);
+        Mockito.when(resourceGetRequest.getResourceId()).thenReturn(resourceId);
+
+        try {
+            Optional<S3Resource> s3ResourceOptional = fileBasedResourceBackend.getS3Resource(resourceGetRequest);
+            assertTrue(s3ResourceOptional.isPresent());
+
+            S3Resource s3Resource = s3ResourceOptional.get();
+            assertEquals(resourceId, s3Resource.getResourceId());
+            assertNotNull(s3Resource.getResourcePath());
+            assertNotNull(s3Resource.getRegion());
+            assertNotNull(s3Resource.getBucketName());
+        } catch (Exception e) {
+            fail("Exception from connector: ", e);
+        }
+    }
+
+    @Test
+    public void testGetBoxResource_WithProperResourceId() {
+        BoxResourceGetRequest resourceGetRequest = Mockito.mock(BoxResourceGetRequest.class);
+        Mockito.when(resourceGetRequest.getResourceId()).thenReturn("WrongResourceId");
+
+        try {
+            assertTrue(fileBasedResourceBackend.getBoxResource(resourceGetRequest).isEmpty());
+        } catch (Exception e) {
+            fail("Exception from connector: ", e);
+        }
+    }
+
+    @Test
+    public void testGetBoxResource_WithWrongResourceId() {
+        String resourceId = "box-file-abcd";
+        BoxResourceGetRequest resourceGetRequest = Mockito.mock(BoxResourceGetRequest.class);
+        Mockito.when(resourceGetRequest.getResourceId()).thenReturn(resourceId);
+
+        try {
+            Optional<BoxResource> boxResourceOptional = fileBasedResourceBackend.getBoxResource(resourceGetRequest);
+            assertTrue(boxResourceOptional.isPresent());
+
+            BoxResource boxResource = boxResourceOptional.get();
+            assertEquals(resourceId, boxResource.getResourceId());
+            assertNotNull(boxResource.getBoxFileId());
+        } catch (Exception e) {
+            fail("Exception from connector: ", e);
+        }
+    }
+
+    @Test
+    public void testGetAzureResource_WithProperResourceId() {
+        AzureResourceGetRequest resourceGetRequest = Mockito.mock(AzureResourceGetRequest.class);
+        Mockito.when(resourceGetRequest.getResourceId()).thenReturn("WrongResourceId");
+
+        try {
+            assertTrue(fileBasedResourceBackend.getAzureResource(resourceGetRequest).isEmpty());
+        } catch (Exception e) {
+            fail("Exception from connector: ", e);
+        }
+    }
+
+    @Test
+    public void testGetAzureResource_WithWrongResourceId() {
+        String resourceId = "azure-blob";
+        AzureResourceGetRequest resourceGetRequest = Mockito.mock(AzureResourceGetRequest.class);
+        Mockito.when(resourceGetRequest.getResourceId()).thenReturn(resourceId);
+
+        try {
+            Optional<AzureResource> azureResourceOptional = fileBasedResourceBackend.getAzureResource(resourceGetRequest);
+            assertTrue(azureResourceOptional.isPresent());
+
+            AzureResource azureResource = azureResourceOptional.get();
+            assertEquals(resourceId, azureResource.getResourceId());
+            assertNotNull(azureResource.getContainer());
+            assertNotNull(azureResource.getBlobName());
+        } catch (Exception e) {
+            fail("Exception from connector: ", e);
+        }
+    }
+
+    @Test
+    public void testGetGCSResource_WithProperResourceId() {
+        GCSResourceGetRequest resourceGetRequest = Mockito.mock(GCSResourceGetRequest.class);
+        Mockito.when(resourceGetRequest.getResourceId()).thenReturn("WrongResourceId");
+
+        try {
+            assertTrue(fileBasedResourceBackend.getGCSResource(resourceGetRequest).isEmpty());
+        } catch (Exception e) {
+            fail("Exception from connector: ", e);
+        }
+    }
+
+    @Test
+    public void testGetGCSResource_WithWrongResourceId() {
+        String resourceId = "gcs-bucket";
+        GCSResourceGetRequest resourceGetRequest = Mockito.mock(GCSResourceGetRequest.class);
+        Mockito.when(resourceGetRequest.getResourceId()).thenReturn(resourceId);
+
+        try {
+            Optional<GCSResource> gcsResourceOptional = fileBasedResourceBackend.getGCSResource(resourceGetRequest);
+            assertTrue(gcsResourceOptional.isPresent());
+
+            GCSResource gcsResource = gcsResourceOptional.get();
+            assertEquals(resourceId, gcsResource.getResourceId());
+            assertNotNull(gcsResource.getBucketName());
+            assertNotNull(gcsResource.getResourcePath());
+        } catch (Exception e) {
+            fail("Exception from connector: ", e);
+        }
+    }
+
+    @Test
+    public void testGetDropboxResource_WithProperResourceId() {
+        DropboxResourceGetRequest resourceGetRequest = Mockito.mock(DropboxResourceGetRequest.class);
+        Mockito.when(resourceGetRequest.getResourceId()).thenReturn("WrongResourceId");
+
+        try {
+            assertTrue(fileBasedResourceBackend.getDropboxResource(resourceGetRequest).isEmpty());
+        } catch (Exception e) {
+            fail("Exception from connector: ", e);
+        }
+    }
+
+    @Test
+    public void testGetDropboxResource_WithWrongResourceId() {
+        String resourceId = "dropbox-file";
+        DropboxResourceGetRequest resourceGetRequest = Mockito.mock(DropboxResourceGetRequest.class);
+        Mockito.when(resourceGetRequest.getResourceId()).thenReturn(resourceId);
+
+        try {
+            Optional<DropboxResource> dropboxResourceOptional = fileBasedResourceBackend.getDropboxResource(resourceGetRequest);
+            assertTrue(dropboxResourceOptional.isPresent());
+
+            DropboxResource dropboxResource = dropboxResourceOptional.get();
+            assertEquals(resourceId, dropboxResource.getResourceId());
+            assertNotNull(dropboxResource.getResourcePath());
+        } catch (Exception e) {
+            fail("Exception from connector: ", e);
+        }
+    }
+
+}

--- a/services/resource-service/server/src/test/java/org/apache/airavata/mft/resource/server/backend/sql/TestSQLResourceBackend.java
+++ b/services/resource-service/server/src/test/java/org/apache/airavata/mft/resource/server/backend/sql/TestSQLResourceBackend.java
@@ -1,0 +1,337 @@
+package org.apache.airavata.mft.resource.server.backend.sql;
+
+import org.apache.airavata.mft.resource.server.backend.sql.entity.LocalResourceEntity;
+import org.apache.airavata.mft.resource.server.backend.sql.entity.SCPResourceEntity;
+import org.apache.airavata.mft.resource.server.backend.sql.entity.SCPStorageEntity;
+import org.apache.airavata.mft.resource.server.backend.sql.repository.LocalResourceRepository;
+import org.apache.airavata.mft.resource.server.backend.sql.repository.SCPResourceRepository;
+import org.apache.airavata.mft.resource.server.backend.sql.repository.SCPStorageRepository;
+import org.apache.airavata.mft.resource.service.*;
+import org.dozer.MappingException;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TestSQLResourceBackend {
+
+    @Test
+    public void testGetSCPStorage() {
+        SQLResourceBackend sqlResourceBackend = Mockito.spy(new SQLResourceBackend());
+        SCPStorageGetRequest scpStorageGetRequest = Mockito.mock(SCPStorageGetRequest.class);
+        SCPStorageRepository scpStorageRepository = Mockito.mock(SCPStorageRepository.class);
+        SCPStorageEntity scpStorageEntity = new SCPStorageEntity();
+
+        String host = "host";
+        int port = 8080;
+        String storageId = "randomStorageId";
+        int user = 1;
+
+        scpStorageEntity.setHost(host);
+        scpStorageEntity.setPort(port);
+        scpStorageEntity.setStorageId(storageId);
+        scpStorageEntity.setUser(user);
+
+        Mockito.doReturn(scpStorageRepository).when(sqlResourceBackend).getScpStorageRepository();
+        Mockito.when(scpStorageRepository.findByStorageId(null)).thenReturn(Optional.of(scpStorageEntity));
+
+        Optional<SCPStorage> scpStorageOptional = sqlResourceBackend.getSCPStorage(scpStorageGetRequest);
+        assertTrue(scpStorageOptional.isPresent());
+        assertEquals(host, scpStorageOptional.get().getHost());
+        assertEquals(port, scpStorageOptional.get().getPort());
+        assertEquals(storageId, scpStorageOptional.get().getStorageId());
+        assertEquals(String.valueOf(user), scpStorageOptional.get().getUser());
+    }
+
+    @Test
+    public void testGetSCPStorage_IncompleteSCPStorageEntity() {
+        SQLResourceBackend sqlResourceBackend = Mockito.spy(new SQLResourceBackend());
+        SCPStorageGetRequest scpStorageGetRequest = Mockito.mock(SCPStorageGetRequest.class);
+        SCPStorageRepository scpStorageRepository = Mockito.mock(SCPStorageRepository.class);
+        SCPStorageEntity scpStorageEntity = new SCPStorageEntity();
+
+        String host = "host";
+        int port = 8080;
+
+        scpStorageEntity.setHost(host);
+        scpStorageEntity.setPort(port);
+
+        Mockito.doReturn(scpStorageRepository).when(sqlResourceBackend).getScpStorageRepository();
+        Mockito.when(scpStorageRepository.findByStorageId(null)).thenReturn(Optional.of(scpStorageEntity));
+
+        assertThrows(MappingException.class, () -> sqlResourceBackend.getSCPStorage(scpStorageGetRequest));
+    }
+
+    @Test
+    public void testCreateSCPStorage() {
+        SQLResourceBackend sqlResourceBackend = Mockito.spy(new SQLResourceBackend());
+        SCPStorageCreateRequest scpStorageCreateRequest = Mockito.mock(SCPStorageCreateRequest.class);
+        SCPStorageRepository scpStorageRepository = Mockito.mock(SCPStorageRepository.class);
+
+        String host = "host";
+        int port = 8080;
+        int user = 1;
+        String storageId = "storageId";
+
+        Mockito.when(scpStorageCreateRequest.getHost()).thenReturn(host);
+
+        Mockito.when(scpStorageRepository.save(Mockito.any(SCPStorageEntity.class))).thenAnswer(invocation -> {
+            SCPStorageEntity entity = invocation.getArgument(0);
+            entity.setUser(user);
+            entity.setPort(port);
+            entity.setStorageId(storageId);
+            return entity;
+        });
+        Mockito.when(sqlResourceBackend.getScpStorageRepository()).thenReturn(scpStorageRepository);
+
+        SCPStorage scpStorage = sqlResourceBackend.createSCPStorage(scpStorageCreateRequest);
+        assertEquals(host, scpStorage.getHost());
+        assertEquals(port, scpStorage.getPort());
+        assertEquals(String.valueOf(user), scpStorage.getUser());
+        assertEquals(storageId, scpStorage.getStorageId());
+    }
+
+    @Test
+    public void testCreateSCPStorage_IncompleteSCPCreateRequest() {
+        SQLResourceBackend sqlResourceBackend = Mockito.spy(new SQLResourceBackend());
+        SCPStorageCreateRequest scpStorageCreateRequest = Mockito.mock(SCPStorageCreateRequest.class);
+        SCPStorageRepository scpStorageRepository = Mockito.mock(SCPStorageRepository.class);
+
+        String host = "host";
+        int port = 8080;
+        int user = 1;
+
+        Mockito.when(scpStorageCreateRequest.getHost()).thenReturn(host);
+
+        Mockito.when(scpStorageRepository.save(Mockito.any(SCPStorageEntity.class))).thenAnswer(invocation -> {
+            SCPStorageEntity entity = invocation.getArgument(0);
+            entity.setUser(user);
+            entity.setPort(port);
+            return entity;
+        });
+        Mockito.when(sqlResourceBackend.getScpStorageRepository()).thenReturn(scpStorageRepository);
+
+        assertThrows(MappingException.class, () -> sqlResourceBackend.createSCPStorage(scpStorageCreateRequest));
+    }
+
+    @Test
+    public void testCreateSCPStorage_EmptySCPCreateRequest() {
+        SQLResourceBackend sqlResourceBackend = Mockito.spy(new SQLResourceBackend());
+        SCPStorageCreateRequest scpStorageCreateRequest = Mockito.mock(SCPStorageCreateRequest.class);
+        SCPStorageRepository scpStorageRepository = Mockito.mock(SCPStorageRepository.class);
+
+        Mockito.doReturn(scpStorageRepository).when(sqlResourceBackend).getScpStorageRepository();
+
+        assertThrows(MappingException.class, () -> sqlResourceBackend.createSCPStorage(scpStorageCreateRequest));
+    }
+
+    @Test
+    public void testGetSCPResource() {
+        SQLResourceBackend sqlResourceBackend = Mockito.spy(new SQLResourceBackend());
+        SCPResourceGetRequest scpResourceGetRequest = Mockito.mock(SCPResourceGetRequest.class);
+        SCPResourceRepository scpResourceRepository = Mockito.mock(SCPResourceRepository.class);
+        SCPResourceEntity scpResourceEntity = Mockito.spy(new SCPResourceEntity());
+
+        SCPStorageEntity scpStorageEntity = new SCPStorageEntity();
+
+        String host = "host";
+        int port = 8080;
+        String storageId = "randomStorageId";
+        int user = 1;
+
+        scpStorageEntity.setHost(host);
+        scpStorageEntity.setPort(port);
+        scpStorageEntity.setStorageId(storageId);
+        scpStorageEntity.setUser(user);
+
+        String resourceId = "resourceId";
+        String resourcePath = "resourcePath";
+        String scpStorageId = "storageId";
+
+        scpResourceEntity.setResourceId(resourceId);
+        scpResourceEntity.setResourcePath(resourcePath);
+        scpResourceEntity.setScpStorage(scpStorageEntity);
+        scpResourceEntity.setScpStorageId(scpStorageId);
+
+        Mockito.doReturn(scpResourceRepository).when(sqlResourceBackend).getScpResourceRepository();
+        Mockito.when(scpResourceRepository.findByResourceId(null)).thenReturn(Optional.of(scpResourceEntity));
+
+        Optional<SCPResource> scpResourceOptional = sqlResourceBackend.getSCPResource(scpResourceGetRequest);
+        assertTrue(scpResourceOptional.isPresent());
+        assertEquals(resourceId, scpResourceOptional.get().getResourceId());
+        assertEquals(resourcePath, scpResourceOptional.get().getResourcePath());
+        assertEquals(storageId, scpResourceOptional.get().getScpStorage().getStorageId());
+        assertEquals(host, scpResourceOptional.get().getScpStorage().getHost());
+        assertEquals(port, scpResourceOptional.get().getScpStorage().getPort());
+        assertEquals(storageId, scpResourceOptional.get().getScpStorage().getStorageId());
+        assertEquals(String.valueOf(user), scpResourceOptional.get().getScpStorage().getUser());
+    }
+
+    @Test
+    public void testGetSCPResource_IncompleteSCPResource() {
+        SQLResourceBackend sqlResourceBackend = Mockito.spy(new SQLResourceBackend());
+        SCPResourceGetRequest scpResourceGetRequest = Mockito.mock(SCPResourceGetRequest.class);
+        SCPResourceRepository scpResourceRepository = Mockito.mock(SCPResourceRepository.class);
+        SCPResourceEntity scpResourceEntity = Mockito.spy(new SCPResourceEntity());
+
+        SCPStorageEntity scpStorageEntity = new SCPStorageEntity();
+
+        String host = "host";
+        int port = 8080;
+        int user = 1;
+
+        scpStorageEntity.setHost(host);
+        scpStorageEntity.setPort(port);
+        scpStorageEntity.setUser(user);
+
+        String resourceId = "resourceId";
+        String resourcePath = "resourcePath";
+        String scpStorageId = "storageId";
+
+        scpResourceEntity.setResourceId(resourceId);
+        scpResourceEntity.setResourcePath(resourcePath);
+        scpResourceEntity.setScpStorage(scpStorageEntity);
+        scpResourceEntity.setScpStorageId(scpStorageId);
+
+        Mockito.doReturn(scpResourceRepository).when(sqlResourceBackend).getScpResourceRepository();
+        Mockito.when(scpResourceRepository.findByResourceId(null)).thenReturn(Optional.of(scpResourceEntity));
+
+        assertThrows(MappingException.class ,() -> sqlResourceBackend.getSCPResource(scpResourceGetRequest));
+    }
+
+    @Test
+    public void testGetSCPResource_IncompleteSCPStorageInSCPResource() {
+        SQLResourceBackend sqlResourceBackend = Mockito.spy(new SQLResourceBackend());
+        SCPResourceGetRequest scpResourceGetRequest = Mockito.mock(SCPResourceGetRequest.class);
+        SCPResourceRepository scpResourceRepository = Mockito.mock(SCPResourceRepository.class);
+        SCPResourceEntity scpResourceEntity = Mockito.spy(new SCPResourceEntity());
+
+        SCPStorageEntity scpStorageEntity = new SCPStorageEntity();
+
+        String host = "host";
+        int port = 8080;
+        String storageId = "randomStorageId";
+        int user = 1;
+
+        scpStorageEntity.setHost(host);
+        scpStorageEntity.setPort(port);
+        scpStorageEntity.setStorageId(storageId);
+        scpStorageEntity.setUser(user);
+
+        String resourceId = "resourceId";
+        String scpStorageId = "storageId";
+
+        scpResourceEntity.setResourceId(resourceId);
+        scpResourceEntity.setScpStorage(scpStorageEntity);
+        scpResourceEntity.setScpStorageId(scpStorageId);
+
+        Mockito.doReturn(scpResourceRepository).when(sqlResourceBackend).getScpResourceRepository();
+        Mockito.when(scpResourceRepository.findByResourceId(null)).thenReturn(Optional.of(scpResourceEntity));
+
+        assertThrows(MappingException.class ,() -> sqlResourceBackend.getSCPResource(scpResourceGetRequest));
+    }
+
+    @Test
+    public void testCreateSCPResource_IncompleteSCPCreateRequest() {
+        SQLResourceBackend sqlResourceBackend = Mockito.spy(new SQLResourceBackend());
+        SCPStorageCreateRequest scpStorageCreateRequest = Mockito.mock(SCPStorageCreateRequest.class);
+        SCPStorageRepository scpStorageRepository = Mockito.mock(SCPStorageRepository.class);
+
+        String host = "host";
+        int port = 8080;
+        int user = 1;
+
+        Mockito.when(scpStorageCreateRequest.getHost()).thenReturn(host);
+
+        Mockito.when(scpStorageRepository.save(Mockito.any(SCPStorageEntity.class))).thenAnswer(invocation -> {
+            SCPStorageEntity entity = invocation.getArgument(0);
+            entity.setUser(user);
+            entity.setPort(port);
+            return entity;
+        });
+        Mockito.when(sqlResourceBackend.getScpStorageRepository()).thenReturn(scpStorageRepository);
+
+        assertThrows(MappingException.class, () -> sqlResourceBackend.createSCPStorage(scpStorageCreateRequest));
+    }
+
+    @Test
+    public void testGetLocalStorage() {
+        SQLResourceBackend sqlResourceBackend = Mockito.spy(new SQLResourceBackend());
+        LocalResourceGetRequest localResourceGetRequest = Mockito.mock(LocalResourceGetRequest.class);
+        LocalResourceRepository localResourceRepository = Mockito.mock( LocalResourceRepository.class);
+        LocalResourceEntity localResourceEntity = new LocalResourceEntity();
+
+        String resourceId = "resourceId";
+        String resourcePath = "resourcePath";
+
+        localResourceEntity.setResourceId(resourceId);
+        localResourceEntity.setResourcePath(resourcePath);
+
+        Mockito.doReturn(localResourceRepository).when(sqlResourceBackend).getLocalResourceRepository();
+        Mockito.when(localResourceRepository.findByResourceId(null)).thenReturn(Optional.of(localResourceEntity));
+
+        Optional<LocalResource> localResourceOptional = sqlResourceBackend.getLocalResource(localResourceGetRequest);
+        assertTrue(localResourceOptional.isPresent());
+        assertEquals(resourceId, localResourceOptional.get().getResourceId());
+        assertEquals(resourcePath, localResourceOptional.get().getResourcePath());
+    }
+
+    @Test
+    public void testGetLocalStorage_IncompleteLocalResouce() {
+        SQLResourceBackend sqlResourceBackend = Mockito.spy(new SQLResourceBackend());
+        LocalResourceGetRequest localResourceGetRequest = Mockito.mock(LocalResourceGetRequest.class);
+        LocalResourceRepository localResourceRepository = Mockito.mock( LocalResourceRepository.class);
+        LocalResourceEntity localResourceEntity = new LocalResourceEntity();
+
+        String resourceId = "resourceId";
+
+        localResourceEntity.setResourceId(resourceId);
+
+        Mockito.doReturn(localResourceRepository).when(sqlResourceBackend).getLocalResourceRepository();
+        Mockito.when(localResourceRepository.findByResourceId(null)).thenReturn(Optional.of(localResourceEntity));
+
+        assertThrows(MappingException.class,() -> sqlResourceBackend.getLocalResource(localResourceGetRequest));
+    }
+
+    @Test
+    public void testCreateLocalResource() {
+        SQLResourceBackend sqlResourceBackend = Mockito.spy(new SQLResourceBackend());
+        LocalResourceCreateRequest localResourceGetRequest = Mockito.mock(LocalResourceCreateRequest.class);
+        LocalResourceRepository localResourceRepository = Mockito.mock( LocalResourceRepository.class);
+
+        String resourceId = "resourceId";
+        String resourcePath = "resourcePath";
+
+        Mockito.when(localResourceRepository.save(Mockito.any(LocalResourceEntity.class))).thenAnswer(invocation -> {
+            LocalResourceEntity entity = invocation.getArgument(0);
+            entity.setResourcePath(resourcePath);
+            entity.setResourceId(resourceId);
+            return entity;
+        });
+        Mockito.when(sqlResourceBackend.getLocalResourceRepository()).thenReturn(localResourceRepository);
+
+        LocalResource localResource = sqlResourceBackend.createLocalResource(localResourceGetRequest);
+        assertEquals(resourceId, localResource.getResourceId());
+        assertEquals(resourcePath, localResource.getResourcePath());
+    }
+
+    @Test
+    public void testCreateLocalResource_IncompleteSCPCreateRequest() {
+        SQLResourceBackend sqlResourceBackend = Mockito.spy(new SQLResourceBackend());
+        LocalResourceCreateRequest localResourceGetRequest = Mockito.mock(LocalResourceCreateRequest.class);
+        LocalResourceRepository localResourceRepository = Mockito.mock( LocalResourceRepository.class);
+
+        String resourceId = "resourceId";
+
+        Mockito.when(localResourceRepository.save(Mockito.any(LocalResourceEntity.class))).thenAnswer(invocation -> {
+            LocalResourceEntity entity = invocation.getArgument(0);
+            entity.setResourceId(resourceId);
+            return entity;
+        });
+        Mockito.when(sqlResourceBackend.getLocalResourceRepository()).thenReturn(localResourceRepository);
+
+        assertThrows(MappingException.class, () -> sqlResourceBackend.createLocalResource(localResourceGetRequest));
+    }
+}

--- a/services/resource-service/server/src/test/java/org/apache/airavata/mft/resource/server/handler/TestResourceServiceHandler.java
+++ b/services/resource-service/server/src/test/java/org/apache/airavata/mft/resource/server/handler/TestResourceServiceHandler.java
@@ -1,0 +1,1688 @@
+package org.apache.airavata.mft.resource.server.handler;
+
+import com.google.protobuf.Empty;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.StreamObserver;
+import org.apache.airavata.mft.resource.server.backend.ResourceBackend;
+import org.apache.airavata.mft.resource.service.*;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TestResourceServiceHandler {
+
+    @Test
+    public void testGetScpStorage() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        SCPStorageGetRequest scpStorageGetRequest = Mockito.mock(SCPStorageGetRequest.class);
+        StreamObserver<SCPStorage> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+        SCPStorage scpStorage = Mockito.mock(SCPStorage.class);
+
+        try {
+            Mockito.when(resourceBackend.getSCPStorage(scpStorageGetRequest)).thenReturn(Optional.of(scpStorage));
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        resourceServiceHandler.getSCPStorage(scpStorageGetRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(1)).onNext(scpStorage);
+        Mockito.verify(streamObserver, Mockito.times(1)).onCompleted();
+    }
+
+    @Test
+    public void testGetScpStorage_EmptyStorage() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        SCPStorageGetRequest scpStorageGetRequest = Mockito.mock(SCPStorageGetRequest.class);
+        StreamObserver<SCPStorage> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.getSCPStorage(scpStorageGetRequest)).thenReturn(Optional.empty());
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        resourceServiceHandler.getSCPStorage(scpStorageGetRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(0)).onNext(Mockito.any(SCPStorage.class));
+        Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+        Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+    }
+
+    @Test
+    public void testGetScpStorage_SCPStorageThrowsError() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        SCPStorageGetRequest scpStorageGetRequest = Mockito.mock(SCPStorageGetRequest.class);
+        StreamObserver<SCPStorage> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.getSCPStorage(scpStorageGetRequest)).thenThrow(new Exception());
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        resourceServiceHandler.getSCPStorage(scpStorageGetRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(0)).onNext(Mockito.any(SCPStorage.class));
+        Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+        Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+    }
+
+    @Test
+    public void testCreateScpStorage() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        SCPStorageCreateRequest scpStorageCreateRequest = Mockito.mock(SCPStorageCreateRequest.class);
+        StreamObserver<SCPStorage> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+        SCPStorage scpStorage = Mockito.mock(SCPStorage.class);
+
+        try {
+            Mockito.when(resourceBackend.createSCPStorage(scpStorageCreateRequest)).thenReturn(scpStorage);
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        resourceServiceHandler.createSCPStorage(scpStorageCreateRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(1)).onNext(scpStorage);
+        Mockito.verify(streamObserver, Mockito.times(1)).onCompleted();
+    }
+
+    @Test
+    public void testCreateScpStorage_CreateThrowsException() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        SCPStorageCreateRequest scpStorageCreateRequest = Mockito.mock(SCPStorageCreateRequest.class);
+        StreamObserver<SCPStorage> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+        SCPStorage scpStorage = Mockito.mock(SCPStorage.class);
+
+        try {
+            Mockito.when(resourceBackend.createSCPStorage(scpStorageCreateRequest)).thenThrow(new Exception());
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        resourceServiceHandler.createSCPStorage(scpStorageCreateRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(0)).onNext(scpStorage);
+        Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+        Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+    }
+
+    @Test
+    public void testUpdateScpStorage() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        SCPStorageUpdateRequest scpStorageUpdateRequest = Mockito.mock(SCPStorageUpdateRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.updateSCPStorage(scpStorageUpdateRequest)).thenReturn(false);
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+
+            resourceServiceHandler.updateSCPStorage(scpStorageUpdateRequest, streamObserver);
+
+            Mockito.verify(resourceBackend, Mockito.times(1)).updateSCPStorage(scpStorageUpdateRequest);
+            Mockito.verify(streamObserver, Mockito.times(1)).onCompleted();
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testUpdateScpStorage_CreateThrowsException() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        SCPStorageUpdateRequest scpStorageUpdateRequest = Mockito.mock(SCPStorageUpdateRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.updateSCPStorage(scpStorageUpdateRequest)).thenThrow(new Exception());
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+
+            resourceServiceHandler.updateSCPStorage(scpStorageUpdateRequest, streamObserver);
+
+            Mockito.verify(resourceBackend, Mockito.times(1)).updateSCPStorage(scpStorageUpdateRequest);
+            Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+            Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testDeleteScpStorageSuccessful() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        SCPStorageDeleteRequest scpStorageDeleteRequest = Mockito.mock(SCPStorageDeleteRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.deleteSCPStorage(scpStorageDeleteRequest)).thenReturn(true);
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+
+            resourceServiceHandler.deleteSCPStorage(scpStorageDeleteRequest, streamObserver);
+
+            Mockito.verify(resourceBackend, Mockito.times(1)).deleteSCPStorage(scpStorageDeleteRequest);
+            Mockito.verify(streamObserver, Mockito.times(1)).onCompleted();
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testDeleteScpStorageFail() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        SCPStorageDeleteRequest scpStorageDeleteRequest = Mockito.mock(SCPStorageDeleteRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.deleteSCPStorage(scpStorageDeleteRequest)).thenReturn(false);
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+
+            resourceServiceHandler.deleteSCPStorage(scpStorageDeleteRequest, streamObserver);
+
+            Mockito.verify(resourceBackend, Mockito.times(1)).deleteSCPStorage(scpStorageDeleteRequest);
+            Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+            Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testDeleteScpStorage_CreateThrowsException() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        SCPStorageDeleteRequest scpStorageDeleteRequest = Mockito.mock(SCPStorageDeleteRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.deleteSCPStorage(scpStorageDeleteRequest)).thenThrow(new Exception());
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+
+            resourceServiceHandler.deleteSCPStorage(scpStorageDeleteRequest, streamObserver);
+
+            Mockito.verify(resourceBackend, Mockito.times(1)).deleteSCPStorage(scpStorageDeleteRequest);
+            Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+            Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testGetScpResource() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        SCPResourceGetRequest scpResourceGetRequest = Mockito.mock(SCPResourceGetRequest.class);
+        StreamObserver<SCPResource> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+        SCPResource scpStorage = Mockito.mock(SCPResource.class);
+
+        try {
+            Mockito.when(resourceBackend.getSCPResource(scpResourceGetRequest)).thenReturn(Optional.of(scpStorage));
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        resourceServiceHandler.getSCPResource(scpResourceGetRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(1)).onNext(scpStorage);
+        Mockito.verify(streamObserver, Mockito.times(1)).onCompleted();
+    }
+
+    @Test
+    public void testGetScpResource_EmptyStorage() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        SCPResourceGetRequest scpResourceGetRequest = Mockito.mock(SCPResourceGetRequest.class);
+        StreamObserver<SCPResource> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.getSCPResource(scpResourceGetRequest)).thenReturn(Optional.empty());
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        resourceServiceHandler.getSCPResource(scpResourceGetRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(0)).onNext(Mockito.any(SCPResource.class));
+        Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+        Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+    }
+
+    @Test
+    public void testGetScpResource_SCPStorageThrowsError() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        SCPResourceGetRequest scpResourceGetRequest = Mockito.mock(SCPResourceGetRequest.class);
+        StreamObserver<SCPResource> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.getSCPResource(scpResourceGetRequest)).thenThrow(new Exception());
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        resourceServiceHandler.getSCPResource(scpResourceGetRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(0)).onNext(Mockito.any(SCPResource.class));
+        Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+        Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+    }
+
+    @Test
+    public void testCreateScpResource() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        SCPResourceCreateRequest scpResourceCreateRequest = Mockito.mock(SCPResourceCreateRequest.class);
+        StreamObserver<SCPResource> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+        SCPResource scpResource = Mockito.mock(SCPResource.class);
+
+        try {
+            Mockito.when(resourceBackend.createSCPResource(scpResourceCreateRequest)).thenReturn(scpResource);
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        resourceServiceHandler.createSCPResource(scpResourceCreateRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(1)).onNext(scpResource);
+        Mockito.verify(streamObserver, Mockito.times(1)).onCompleted();
+    }
+
+    @Test
+    public void testCreateScpResource_CreateThrowsException() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        SCPResourceCreateRequest scpResourceCreateRequest = Mockito.mock(SCPResourceCreateRequest.class);
+        StreamObserver<SCPResource> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+        SCPResource scpResource = Mockito.mock(SCPResource.class);
+
+        try {
+            Mockito.when(resourceBackend.createSCPResource(scpResourceCreateRequest)).thenThrow(new Exception());
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        resourceServiceHandler.createSCPResource(scpResourceCreateRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(0)).onNext(scpResource);
+        Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+        Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+    }
+
+    @Test
+    public void testUpdateScpResource() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        SCPResourceUpdateRequest scpResourceUpdateRequest = Mockito.mock(SCPResourceUpdateRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.updateSCPResource(scpResourceUpdateRequest)).thenReturn(false);
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+
+            resourceServiceHandler.updateSCPResource(scpResourceUpdateRequest, streamObserver);
+
+            Mockito.verify(resourceBackend, Mockito.times(1)).updateSCPResource(scpResourceUpdateRequest);
+            Mockito.verify(streamObserver, Mockito.times(1)).onCompleted();
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testUpdateScpResource_CreateThrowsException() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        SCPResourceUpdateRequest scpResourceUpdateRequest = Mockito.mock(SCPResourceUpdateRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.updateSCPResource(scpResourceUpdateRequest)).thenThrow(new Exception());
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+
+            resourceServiceHandler.updateSCPResource(scpResourceUpdateRequest, streamObserver);
+
+            Mockito.verify(resourceBackend, Mockito.times(1)).updateSCPResource(scpResourceUpdateRequest);
+            Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+            Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testDeleteScpResourceSuccessful() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        SCPResourceDeleteRequest scpResourceDeleteRequest = Mockito.mock(SCPResourceDeleteRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.deleteSCPResource(scpResourceDeleteRequest)).thenReturn(true);
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+
+            resourceServiceHandler.deleteSCPResource(scpResourceDeleteRequest, streamObserver);
+
+            Mockito.verify(resourceBackend, Mockito.times(1)).deleteSCPResource(scpResourceDeleteRequest);
+            Mockito.verify(streamObserver, Mockito.times(1)).onCompleted();
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testDeleteScpResourceFail() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        SCPResourceDeleteRequest scpResourceDeleteRequest = Mockito.mock(SCPResourceDeleteRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.deleteSCPResource(scpResourceDeleteRequest)).thenReturn(false);
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+
+            resourceServiceHandler.deleteSCPResource(scpResourceDeleteRequest, streamObserver);
+
+            Mockito.verify(resourceBackend, Mockito.times(1)).deleteSCPResource(scpResourceDeleteRequest);
+            Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+            Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testDeleteScpResource_CreateThrowsException() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        SCPResourceDeleteRequest scpResourceDeleteRequest = Mockito.mock(SCPResourceDeleteRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.deleteSCPResource(scpResourceDeleteRequest)).thenThrow(new Exception());
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+
+            resourceServiceHandler.deleteSCPResource(scpResourceDeleteRequest, streamObserver);
+
+            Mockito.verify(resourceBackend, Mockito.times(1)).deleteSCPResource(scpResourceDeleteRequest);
+            Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+            Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testGetLocalResource() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        LocalResourceGetRequest resourceRequest = Mockito.mock(LocalResourceGetRequest.class);
+        StreamObserver<LocalResource> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+        LocalResource scpStorage = Mockito.mock(LocalResource.class);
+
+        try {
+            Mockito.when(resourceBackend.getLocalResource(resourceRequest)).thenReturn(Optional.of(scpStorage));
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        resourceServiceHandler.getLocalResource(resourceRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(1)).onNext(scpStorage);
+        Mockito.verify(streamObserver, Mockito.times(1)).onCompleted();
+    }
+
+    @Test
+    public void testGetLocalResource_EmptyStorage() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        LocalResourceGetRequest LocalResourceGetRequest = Mockito.mock(LocalResourceGetRequest.class);
+        StreamObserver<LocalResource> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.getLocalResource(LocalResourceGetRequest)).thenReturn(Optional.empty());
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        resourceServiceHandler.getLocalResource(LocalResourceGetRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(0)).onNext(Mockito.any(LocalResource.class));
+        Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+        Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+    }
+
+    @Test
+    public void testGetLocalResource_SCPStorageThrowsError() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        LocalResourceGetRequest LocalResourceGetRequest = Mockito.mock(LocalResourceGetRequest.class);
+        StreamObserver<LocalResource> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.getLocalResource(LocalResourceGetRequest)).thenThrow(new Exception());
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        resourceServiceHandler.getLocalResource(LocalResourceGetRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(0)).onNext(Mockito.any(LocalResource.class));
+        Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+        Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+    }
+
+    @Test
+    public void testCreateLocalResource() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        LocalResourceCreateRequest LocalResourceCreateRequest = Mockito.mock(LocalResourceCreateRequest.class);
+        StreamObserver<LocalResource> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+        LocalResource LocalResource = Mockito.mock(LocalResource.class);
+
+        try {
+            Mockito.when(resourceBackend.createLocalResource(LocalResourceCreateRequest)).thenReturn(LocalResource);
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        resourceServiceHandler.createLocalResource(LocalResourceCreateRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(1)).onNext(LocalResource);
+        Mockito.verify(streamObserver, Mockito.times(1)).onCompleted();
+    }
+
+    @Test
+    public void testCreateLocalResource_CreateThrowsException() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        LocalResourceCreateRequest LocalResourceCreateRequest = Mockito.mock(LocalResourceCreateRequest.class);
+        StreamObserver<LocalResource> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+        LocalResource LocalResource = Mockito.mock(LocalResource.class);
+
+        try {
+            Mockito.when(resourceBackend.createLocalResource(LocalResourceCreateRequest)).thenThrow(new Exception());
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        resourceServiceHandler.createLocalResource(LocalResourceCreateRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(0)).onNext(LocalResource);
+        Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+        Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+    }
+
+    @Test
+    public void testUpdateLocalResource() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        LocalResourceUpdateRequest LocalResourceUpdateRequest = Mockito.mock(LocalResourceUpdateRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.updateLocalResource(LocalResourceUpdateRequest)).thenReturn(false);
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+
+            resourceServiceHandler.updateLocalResource(LocalResourceUpdateRequest, streamObserver);
+
+            Mockito.verify(resourceBackend, Mockito.times(1)).updateLocalResource(LocalResourceUpdateRequest);
+            Mockito.verify(streamObserver, Mockito.times(1)).onCompleted();
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testUpdateLocalResource_CreateThrowsException() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        LocalResourceUpdateRequest LocalResourceUpdateRequest = Mockito.mock(LocalResourceUpdateRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.updateLocalResource(LocalResourceUpdateRequest)).thenThrow(new Exception());
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+
+            resourceServiceHandler.updateLocalResource(LocalResourceUpdateRequest, streamObserver);
+
+            Mockito.verify(resourceBackend, Mockito.times(1)).updateLocalResource(LocalResourceUpdateRequest);
+            Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+            Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testDeleteLocalResourceSuccessful() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        LocalResourceDeleteRequest LocalResourceDeleteRequest = Mockito.mock(LocalResourceDeleteRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.deleteLocalResource(LocalResourceDeleteRequest)).thenReturn(true);
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+
+            resourceServiceHandler.deleteLocalResource(LocalResourceDeleteRequest, streamObserver);
+
+            Mockito.verify(resourceBackend, Mockito.times(1)).deleteLocalResource(LocalResourceDeleteRequest);
+            Mockito.verify(streamObserver, Mockito.times(1)).onCompleted();
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testDeleteLocalResourceFail() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        LocalResourceDeleteRequest LocalResourceDeleteRequest = Mockito.mock(LocalResourceDeleteRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.deleteLocalResource(LocalResourceDeleteRequest)).thenReturn(false);
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+
+            resourceServiceHandler.deleteLocalResource(LocalResourceDeleteRequest, streamObserver);
+
+            Mockito.verify(resourceBackend, Mockito.times(1)).deleteLocalResource(LocalResourceDeleteRequest);
+            Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+            Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(Exception.class));
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testDeleteLocalResource_CreateThrowsException() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        LocalResourceDeleteRequest LocalResourceDeleteRequest = Mockito.mock(LocalResourceDeleteRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.deleteLocalResource(LocalResourceDeleteRequest)).thenThrow(new Exception());
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+
+            resourceServiceHandler.deleteLocalResource(LocalResourceDeleteRequest, streamObserver);
+
+            Mockito.verify(resourceBackend, Mockito.times(1)).deleteLocalResource(LocalResourceDeleteRequest);
+            Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+            Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testGetS3Resource() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        S3ResourceGetRequest resourceRequest = Mockito.mock(S3ResourceGetRequest.class);
+        StreamObserver<S3Resource> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+        S3Resource scpStorage = Mockito.mock(S3Resource.class);
+
+        try {
+            Mockito.when(resourceBackend.getS3Resource(resourceRequest)).thenReturn(Optional.of(scpStorage));
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        resourceServiceHandler.getS3Resource(resourceRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(1)).onNext(scpStorage);
+        Mockito.verify(streamObserver, Mockito.times(1)).onCompleted();
+    }
+
+    @Test
+    public void testGetS3Resource_EmptyStorage() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        S3ResourceGetRequest S3ResourceGetRequest = Mockito.mock(S3ResourceGetRequest.class);
+        StreamObserver<S3Resource> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.getS3Resource(S3ResourceGetRequest)).thenReturn(Optional.empty());
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        resourceServiceHandler.getS3Resource(S3ResourceGetRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(0)).onNext(Mockito.any(S3Resource.class));
+        Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+        Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+    }
+
+    @Test
+    public void testGetS3Resource_SCPStorageThrowsError() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        S3ResourceGetRequest S3ResourceGetRequest = Mockito.mock(S3ResourceGetRequest.class);
+        StreamObserver<S3Resource> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.getS3Resource(S3ResourceGetRequest)).thenThrow(new Exception());
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        resourceServiceHandler.getS3Resource(S3ResourceGetRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(0)).onNext(Mockito.any(S3Resource.class));
+        Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+        Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+    }
+
+    @Test
+    public void testCreateS3Resource() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        S3ResourceCreateRequest S3ResourceCreateRequest = Mockito.mock(S3ResourceCreateRequest.class);
+        StreamObserver<S3Resource> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+        S3Resource S3Resource = Mockito.mock(S3Resource.class);
+
+        try {
+            Mockito.when(resourceBackend.createS3Resource(S3ResourceCreateRequest)).thenReturn(S3Resource);
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        resourceServiceHandler.createS3Resource(S3ResourceCreateRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(1)).onNext(S3Resource);
+        Mockito.verify(streamObserver, Mockito.times(1)).onCompleted();
+    }
+
+    @Test
+    public void testCreateS3Resource_CreateThrowsException() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        S3ResourceCreateRequest S3ResourceCreateRequest = Mockito.mock(S3ResourceCreateRequest.class);
+        StreamObserver<S3Resource> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+        S3Resource S3Resource = Mockito.mock(S3Resource.class);
+
+        try {
+            Mockito.when(resourceBackend.createS3Resource(S3ResourceCreateRequest)).thenThrow(new Exception());
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        resourceServiceHandler.createS3Resource(S3ResourceCreateRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(0)).onNext(S3Resource);
+        Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+        Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+    }
+
+    @Test
+    public void testUpdateS3Resource() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        S3ResourceUpdateRequest S3ResourceUpdateRequest = Mockito.mock(S3ResourceUpdateRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.updateS3Resource(S3ResourceUpdateRequest)).thenReturn(false);
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+
+            resourceServiceHandler.updateS3Resource(S3ResourceUpdateRequest, streamObserver);
+
+            Mockito.verify(resourceBackend, Mockito.times(1)).updateS3Resource(S3ResourceUpdateRequest);
+            Mockito.verify(streamObserver, Mockito.times(1)).onCompleted();
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testUpdateS3Resource_CreateThrowsException() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        S3ResourceUpdateRequest S3ResourceUpdateRequest = Mockito.mock(S3ResourceUpdateRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.updateS3Resource(S3ResourceUpdateRequest)).thenThrow(new Exception());
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+
+            resourceServiceHandler.updateS3Resource(S3ResourceUpdateRequest, streamObserver);
+
+            Mockito.verify(resourceBackend, Mockito.times(1)).updateS3Resource(S3ResourceUpdateRequest);
+            Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+            Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testDeleteS3ResourceSuccessful() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        S3ResourceDeleteRequest S3ResourceDeleteRequest = Mockito.mock(S3ResourceDeleteRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.deleteS3Resource(S3ResourceDeleteRequest)).thenReturn(true);
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+
+            resourceServiceHandler.deleteS3Resource(S3ResourceDeleteRequest, streamObserver);
+
+            Mockito.verify(resourceBackend, Mockito.times(1)).deleteS3Resource(S3ResourceDeleteRequest);
+            Mockito.verify(streamObserver, Mockito.times(1)).onCompleted();
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testDeleteS3ResourceFail() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        S3ResourceDeleteRequest S3ResourceDeleteRequest = Mockito.mock(S3ResourceDeleteRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.deleteS3Resource(S3ResourceDeleteRequest)).thenReturn(false);
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+
+            resourceServiceHandler.deleteS3Resource(S3ResourceDeleteRequest, streamObserver);
+
+            Mockito.verify(resourceBackend, Mockito.times(1)).deleteS3Resource(S3ResourceDeleteRequest);
+            Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+            Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(Exception.class));
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testDeleteS3Resource_CreateThrowsException() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        S3ResourceDeleteRequest S3ResourceDeleteRequest = Mockito.mock(S3ResourceDeleteRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.deleteS3Resource(S3ResourceDeleteRequest)).thenThrow(new Exception());
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+
+            resourceServiceHandler.deleteS3Resource(S3ResourceDeleteRequest, streamObserver);
+
+            Mockito.verify(resourceBackend, Mockito.times(1)).deleteS3Resource(S3ResourceDeleteRequest);
+            Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+            Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testGetBoxResource() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        BoxResourceGetRequest resourceRequest = Mockito.mock(BoxResourceGetRequest.class);
+        StreamObserver<BoxResource> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+        BoxResource scpStorage = Mockito.mock(BoxResource.class);
+
+        try {
+            Mockito.when(resourceBackend.getBoxResource(resourceRequest)).thenReturn(Optional.of(scpStorage));
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        resourceServiceHandler.getBoxResource(resourceRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(1)).onNext(scpStorage);
+        Mockito.verify(streamObserver, Mockito.times(1)).onCompleted();
+    }
+
+    @Test
+    public void testGetBoxResource_EmptyStorage() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        BoxResourceGetRequest BoxResourceGetRequest = Mockito.mock(BoxResourceGetRequest.class);
+        StreamObserver<BoxResource> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.getBoxResource(BoxResourceGetRequest)).thenReturn(Optional.empty());
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        resourceServiceHandler.getBoxResource(BoxResourceGetRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(0)).onNext(Mockito.any(BoxResource.class));
+        Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+        Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+    }
+
+    @Test
+    public void testGetBoxResource_SCPStorageThrowsError() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        BoxResourceGetRequest BoxResourceGetRequest = Mockito.mock(BoxResourceGetRequest.class);
+        StreamObserver<BoxResource> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.getBoxResource(BoxResourceGetRequest)).thenThrow(new Exception());
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        resourceServiceHandler.getBoxResource(BoxResourceGetRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(0)).onNext(Mockito.any(BoxResource.class));
+        Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+        Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+    }
+
+    @Test
+    public void testCreateBoxResource() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        BoxResourceCreateRequest BoxResourceCreateRequest = Mockito.mock(BoxResourceCreateRequest.class);
+        StreamObserver<BoxResource> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+        BoxResource BoxResource = Mockito.mock(BoxResource.class);
+
+        try {
+            Mockito.when(resourceBackend.createBoxResource(BoxResourceCreateRequest)).thenReturn(BoxResource);
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        resourceServiceHandler.createBoxResource(BoxResourceCreateRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(1)).onNext(BoxResource);
+        Mockito.verify(streamObserver, Mockito.times(1)).onCompleted();
+    }
+
+    @Test
+    public void testCreateBoxResource_CreateThrowsException() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        BoxResourceCreateRequest BoxResourceCreateRequest = Mockito.mock(BoxResourceCreateRequest.class);
+        StreamObserver<BoxResource> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+        BoxResource BoxResource = Mockito.mock(BoxResource.class);
+
+        try {
+            Mockito.when(resourceBackend.createBoxResource(BoxResourceCreateRequest)).thenThrow(new Exception());
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        resourceServiceHandler.createBoxResource(BoxResourceCreateRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(0)).onNext(BoxResource);
+        Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+        Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+    }
+
+    @Test
+    public void testUpdateBoxResource() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        BoxResourceUpdateRequest BoxResourceUpdateRequest = Mockito.mock(BoxResourceUpdateRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.updateBoxResource(BoxResourceUpdateRequest)).thenReturn(false);
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+
+            resourceServiceHandler.updateBoxResource(BoxResourceUpdateRequest, streamObserver);
+
+            Mockito.verify(resourceBackend, Mockito.times(1)).updateBoxResource(BoxResourceUpdateRequest);
+            Mockito.verify(streamObserver, Mockito.times(1)).onCompleted();
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testUpdateBoxResource_CreateThrowsException() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        BoxResourceUpdateRequest BoxResourceUpdateRequest = Mockito.mock(BoxResourceUpdateRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.updateBoxResource(BoxResourceUpdateRequest)).thenThrow(new Exception());
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+
+            resourceServiceHandler.updateBoxResource(BoxResourceUpdateRequest, streamObserver);
+
+            Mockito.verify(resourceBackend, Mockito.times(1)).updateBoxResource(BoxResourceUpdateRequest);
+            Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+            Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testDeleteBoxResourceSuccessful() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        BoxResourceDeleteRequest BoxResourceDeleteRequest = Mockito.mock(BoxResourceDeleteRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.deleteBoxResource(BoxResourceDeleteRequest)).thenReturn(true);
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+
+            resourceServiceHandler.deleteBoxResource(BoxResourceDeleteRequest, streamObserver);
+
+            Mockito.verify(resourceBackend, Mockito.times(1)).deleteBoxResource(BoxResourceDeleteRequest);
+            Mockito.verify(streamObserver, Mockito.times(1)).onCompleted();
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testDeleteBoxResourceFail() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        BoxResourceDeleteRequest BoxResourceDeleteRequest = Mockito.mock(BoxResourceDeleteRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.deleteBoxResource(BoxResourceDeleteRequest)).thenReturn(false);
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+
+            resourceServiceHandler.deleteBoxResource(BoxResourceDeleteRequest, streamObserver);
+
+            Mockito.verify(resourceBackend, Mockito.times(1)).deleteBoxResource(BoxResourceDeleteRequest);
+            Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+            Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(Exception.class));
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testDeleteBoxResource_CreateThrowsException() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        BoxResourceDeleteRequest BoxResourceDeleteRequest = Mockito.mock(BoxResourceDeleteRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.deleteBoxResource(BoxResourceDeleteRequest)).thenThrow(new Exception());
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+
+            resourceServiceHandler.deleteBoxResource(BoxResourceDeleteRequest, streamObserver);
+
+            Mockito.verify(resourceBackend, Mockito.times(1)).deleteBoxResource(BoxResourceDeleteRequest);
+            Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+            Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testGetAzureResource() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        AzureResourceGetRequest resourceRequest = Mockito.mock(AzureResourceGetRequest.class);
+        StreamObserver<AzureResource> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+        AzureResource scpStorage = Mockito.mock(AzureResource.class);
+
+        try {
+            Mockito.when(resourceBackend.getAzureResource(resourceRequest)).thenReturn(Optional.of(scpStorage));
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        resourceServiceHandler.getAzureResource(resourceRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(1)).onNext(scpStorage);
+        Mockito.verify(streamObserver, Mockito.times(1)).onCompleted();
+    }
+
+    @Test
+    public void testGetAzureResource_EmptyStorage() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        AzureResourceGetRequest AzureResourceGetRequest = Mockito.mock(AzureResourceGetRequest.class);
+        StreamObserver<AzureResource> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.getAzureResource(AzureResourceGetRequest)).thenReturn(Optional.empty());
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        resourceServiceHandler.getAzureResource(AzureResourceGetRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(0)).onNext(Mockito.any(AzureResource.class));
+        Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+        Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+    }
+
+    @Test
+    public void testGetAzureResource_SCPStorageThrowsError() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        AzureResourceGetRequest AzureResourceGetRequest = Mockito.mock(AzureResourceGetRequest.class);
+        StreamObserver<AzureResource> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.getAzureResource(AzureResourceGetRequest)).thenThrow(new Exception());
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        resourceServiceHandler.getAzureResource(AzureResourceGetRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(0)).onNext(Mockito.any(AzureResource.class));
+        Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+        Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+    }
+
+    @Test
+    public void testCreateAzureResource() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        AzureResourceCreateRequest AzureResourceCreateRequest = Mockito.mock(AzureResourceCreateRequest.class);
+        StreamObserver<AzureResource> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+        AzureResource AzureResource = Mockito.mock(AzureResource.class);
+
+        try {
+            Mockito.when(resourceBackend.createAzureResource(AzureResourceCreateRequest)).thenReturn(AzureResource);
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        resourceServiceHandler.createAzureResource(AzureResourceCreateRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(1)).onNext(AzureResource);
+        Mockito.verify(streamObserver, Mockito.times(1)).onCompleted();
+    }
+
+    @Test
+    public void testCreateAzureResource_CreateThrowsException() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        AzureResourceCreateRequest AzureResourceCreateRequest = Mockito.mock(AzureResourceCreateRequest.class);
+        StreamObserver<AzureResource> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+        AzureResource AzureResource = Mockito.mock(AzureResource.class);
+
+        try {
+            Mockito.when(resourceBackend.createAzureResource(AzureResourceCreateRequest)).thenThrow(new Exception());
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        resourceServiceHandler.createAzureResource(AzureResourceCreateRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(0)).onNext(AzureResource);
+        Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+        Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+    }
+
+    @Test
+    public void testUpdateAzureResource() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        AzureResourceUpdateRequest AzureResourceUpdateRequest = Mockito.mock(AzureResourceUpdateRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.updateAzureResource(AzureResourceUpdateRequest)).thenReturn(false);
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+
+            resourceServiceHandler.updateAzureResource(AzureResourceUpdateRequest, streamObserver);
+
+            Mockito.verify(resourceBackend, Mockito.times(1)).updateAzureResource(AzureResourceUpdateRequest);
+            Mockito.verify(streamObserver, Mockito.times(1)).onCompleted();
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testUpdateAzureResource_CreateThrowsException() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        AzureResourceUpdateRequest AzureResourceUpdateRequest = Mockito.mock(AzureResourceUpdateRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.updateAzureResource(AzureResourceUpdateRequest)).thenThrow(new Exception());
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+
+            resourceServiceHandler.updateAzureResource(AzureResourceUpdateRequest, streamObserver);
+
+            Mockito.verify(resourceBackend, Mockito.times(1)).updateAzureResource(AzureResourceUpdateRequest);
+            Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+            Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testDeleteAzureResourceSuccessful() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        AzureResourceDeleteRequest AzureResourceDeleteRequest = Mockito.mock(AzureResourceDeleteRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.deleteAzureResource(AzureResourceDeleteRequest)).thenReturn(true);
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+
+            resourceServiceHandler.deleteAzureResource(AzureResourceDeleteRequest, streamObserver);
+
+            Mockito.verify(resourceBackend, Mockito.times(1)).deleteAzureResource(AzureResourceDeleteRequest);
+            Mockito.verify(streamObserver, Mockito.times(1)).onCompleted();
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testDeleteAzureResourceFail() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        AzureResourceDeleteRequest AzureResourceDeleteRequest = Mockito.mock(AzureResourceDeleteRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.deleteAzureResource(AzureResourceDeleteRequest)).thenReturn(false);
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+
+            resourceServiceHandler.deleteAzureResource(AzureResourceDeleteRequest, streamObserver);
+
+            Mockito.verify(resourceBackend, Mockito.times(1)).deleteAzureResource(AzureResourceDeleteRequest);
+            Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+            Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(Exception.class));
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testDeleteAzureResource_CreateThrowsException() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        AzureResourceDeleteRequest AzureResourceDeleteRequest = Mockito.mock(AzureResourceDeleteRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.deleteAzureResource(AzureResourceDeleteRequest)).thenThrow(new Exception());
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+
+            resourceServiceHandler.deleteAzureResource(AzureResourceDeleteRequest, streamObserver);
+
+            Mockito.verify(resourceBackend, Mockito.times(1)).deleteAzureResource(AzureResourceDeleteRequest);
+            Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+            Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testGetGCSResource() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        GCSResourceGetRequest resourceRequest = Mockito.mock(GCSResourceGetRequest.class);
+        StreamObserver<GCSResource> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+        GCSResource scpStorage = Mockito.mock(GCSResource.class);
+
+        try {
+            Mockito.when(resourceBackend.getGCSResource(resourceRequest)).thenReturn(Optional.of(scpStorage));
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        resourceServiceHandler.getGCSResource(resourceRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(1)).onNext(scpStorage);
+        Mockito.verify(streamObserver, Mockito.times(1)).onCompleted();
+    }
+
+    @Test
+    public void testGetGCSResource_EmptyStorage() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        GCSResourceGetRequest GCSResourceGetRequest = Mockito.mock(GCSResourceGetRequest.class);
+        StreamObserver<GCSResource> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.getGCSResource(GCSResourceGetRequest)).thenReturn(Optional.empty());
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        resourceServiceHandler.getGCSResource(GCSResourceGetRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(0)).onNext(Mockito.any(GCSResource.class));
+        Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+        Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+    }
+
+    @Test
+    public void testGetGCSResource_SCPStorageThrowsError() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        GCSResourceGetRequest GCSResourceGetRequest = Mockito.mock(GCSResourceGetRequest.class);
+        StreamObserver<GCSResource> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.getGCSResource(GCSResourceGetRequest)).thenThrow(new Exception());
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        resourceServiceHandler.getGCSResource(GCSResourceGetRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(0)).onNext(Mockito.any(GCSResource.class));
+        Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+        Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+    }
+
+    @Test
+    public void testCreateGCSResource() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        GCSResourceCreateRequest GCSResourceCreateRequest = Mockito.mock(GCSResourceCreateRequest.class);
+        StreamObserver<GCSResource> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+        GCSResource GCSResource = Mockito.mock(GCSResource.class);
+
+        try {
+            Mockito.when(resourceBackend.createGCSResource(GCSResourceCreateRequest)).thenReturn(GCSResource);
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        resourceServiceHandler.createGCSResource(GCSResourceCreateRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(1)).onNext(GCSResource);
+        Mockito.verify(streamObserver, Mockito.times(1)).onCompleted();
+    }
+
+    @Test
+    public void testCreateGCSResource_CreateThrowsException() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        GCSResourceCreateRequest GCSResourceCreateRequest = Mockito.mock(GCSResourceCreateRequest.class);
+        StreamObserver<GCSResource> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+        GCSResource GCSResource = Mockito.mock(GCSResource.class);
+
+        try {
+            Mockito.when(resourceBackend.createGCSResource(GCSResourceCreateRequest)).thenThrow(new Exception());
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        resourceServiceHandler.createGCSResource(GCSResourceCreateRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(0)).onNext(GCSResource);
+        Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+        Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+    }
+
+    @Test
+    public void testUpdateGCSResource() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        GCSResourceUpdateRequest GCSResourceUpdateRequest = Mockito.mock(GCSResourceUpdateRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.updateGCSResource(GCSResourceUpdateRequest)).thenReturn(false);
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+
+            resourceServiceHandler.updateGCSResource(GCSResourceUpdateRequest, streamObserver);
+
+            Mockito.verify(resourceBackend, Mockito.times(1)).updateGCSResource(GCSResourceUpdateRequest);
+            Mockito.verify(streamObserver, Mockito.times(1)).onCompleted();
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testUpdateGCSResource_CreateThrowsException() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        GCSResourceUpdateRequest GCSResourceUpdateRequest = Mockito.mock(GCSResourceUpdateRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.updateGCSResource(GCSResourceUpdateRequest)).thenThrow(new Exception());
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+
+            resourceServiceHandler.updateGCSResource(GCSResourceUpdateRequest, streamObserver);
+
+            Mockito.verify(resourceBackend, Mockito.times(1)).updateGCSResource(GCSResourceUpdateRequest);
+            Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+            Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testDeleteGCSResourceSuccessful() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        GCSResourceDeleteRequest GCSResourceDeleteRequest = Mockito.mock(GCSResourceDeleteRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.deleteGCSResource(GCSResourceDeleteRequest)).thenReturn(true);
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+
+            resourceServiceHandler.deleteGCSResource(GCSResourceDeleteRequest, streamObserver);
+
+            Mockito.verify(resourceBackend, Mockito.times(1)).deleteGCSResource(GCSResourceDeleteRequest);
+            Mockito.verify(streamObserver, Mockito.times(1)).onCompleted();
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testDeleteGCSResourceFail() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        GCSResourceDeleteRequest GCSResourceDeleteRequest = Mockito.mock(GCSResourceDeleteRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.deleteGCSResource(GCSResourceDeleteRequest)).thenReturn(false);
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+
+            resourceServiceHandler.deleteGCSResource(GCSResourceDeleteRequest, streamObserver);
+
+            Mockito.verify(resourceBackend, Mockito.times(1)).deleteGCSResource(GCSResourceDeleteRequest);
+            Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+            Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(Exception.class));
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testDeleteGCSResource_CreateThrowsException() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        GCSResourceDeleteRequest GCSResourceDeleteRequest = Mockito.mock(GCSResourceDeleteRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.deleteGCSResource(GCSResourceDeleteRequest)).thenThrow(new Exception());
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+
+            resourceServiceHandler.deleteGCSResource(GCSResourceDeleteRequest, streamObserver);
+
+            Mockito.verify(resourceBackend, Mockito.times(1)).deleteGCSResource(GCSResourceDeleteRequest);
+            Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+            Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testGetDropboxResource() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        DropboxResourceGetRequest resourceRequest = Mockito.mock(DropboxResourceGetRequest.class);
+        StreamObserver<DropboxResource> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+        DropboxResource scpStorage = Mockito.mock(DropboxResource.class);
+
+        try {
+            Mockito.when(resourceBackend.getDropboxResource(resourceRequest)).thenReturn(Optional.of(scpStorage));
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        resourceServiceHandler.getDropboxResource(resourceRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(1)).onNext(scpStorage);
+        Mockito.verify(streamObserver, Mockito.times(1)).onCompleted();
+    }
+
+    @Test
+    public void testGetDropboxResource_EmptyStorage() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        DropboxResourceGetRequest DropboxResourceGetRequest = Mockito.mock(DropboxResourceGetRequest.class);
+        StreamObserver<DropboxResource> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.getDropboxResource(DropboxResourceGetRequest)).thenReturn(Optional.empty());
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        resourceServiceHandler.getDropboxResource(DropboxResourceGetRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(0)).onNext(Mockito.any(DropboxResource.class));
+        Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+        Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+    }
+
+    @Test
+    public void testGetDropboxResource_SCPStorageThrowsError() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        DropboxResourceGetRequest DropboxResourceGetRequest = Mockito.mock(DropboxResourceGetRequest.class);
+        StreamObserver<DropboxResource> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.getDropboxResource(DropboxResourceGetRequest)).thenThrow(new Exception());
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        resourceServiceHandler.getDropboxResource(DropboxResourceGetRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(0)).onNext(Mockito.any(DropboxResource.class));
+        Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+        Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+    }
+
+    @Test
+    public void testCreateDropboxResource() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        DropboxResourceCreateRequest DropboxResourceCreateRequest = Mockito.mock(DropboxResourceCreateRequest.class);
+        StreamObserver<DropboxResource> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+        DropboxResource DropboxResource = Mockito.mock(DropboxResource.class);
+
+        try {
+            Mockito.when(resourceBackend.createDropboxResource(DropboxResourceCreateRequest)).thenReturn(DropboxResource);
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        resourceServiceHandler.createDropboxResource(DropboxResourceCreateRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(1)).onNext(DropboxResource);
+        Mockito.verify(streamObserver, Mockito.times(1)).onCompleted();
+    }
+
+    @Test
+    public void testCreateDropboxResource_CreateThrowsException() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        DropboxResourceCreateRequest DropboxResourceCreateRequest = Mockito.mock(DropboxResourceCreateRequest.class);
+        StreamObserver<DropboxResource> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+        DropboxResource DropboxResource = Mockito.mock(DropboxResource.class);
+
+        try {
+            Mockito.when(resourceBackend.createDropboxResource(DropboxResourceCreateRequest)).thenThrow(new Exception());
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        resourceServiceHandler.createDropboxResource(DropboxResourceCreateRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(0)).onNext(DropboxResource);
+        Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+        Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+    }
+
+    @Test
+    public void testUpdateDropboxResource() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        DropboxResourceUpdateRequest DropboxResourceUpdateRequest = Mockito.mock(DropboxResourceUpdateRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.updateDropboxResource(DropboxResourceUpdateRequest)).thenReturn(false);
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+
+            resourceServiceHandler.updateDropboxResource(DropboxResourceUpdateRequest, streamObserver);
+
+            Mockito.verify(resourceBackend, Mockito.times(1)).updateDropboxResource(DropboxResourceUpdateRequest);
+            Mockito.verify(streamObserver, Mockito.times(1)).onCompleted();
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testUpdateDropboxResource_CreateThrowsException() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        DropboxResourceUpdateRequest DropboxResourceUpdateRequest = Mockito.mock(DropboxResourceUpdateRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.updateDropboxResource(DropboxResourceUpdateRequest)).thenThrow(new Exception());
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+
+            resourceServiceHandler.updateDropboxResource(DropboxResourceUpdateRequest, streamObserver);
+
+            Mockito.verify(resourceBackend, Mockito.times(1)).updateDropboxResource(DropboxResourceUpdateRequest);
+            Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+            Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testDeleteDropboxResourceSuccessful() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        DropboxResourceDeleteRequest DropboxResourceDeleteRequest = Mockito.mock(DropboxResourceDeleteRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.deleteDropboxResource(DropboxResourceDeleteRequest)).thenReturn(true);
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+
+            resourceServiceHandler.deleteDropboxResource(DropboxResourceDeleteRequest, streamObserver);
+
+            Mockito.verify(resourceBackend, Mockito.times(1)).deleteDropboxResource(DropboxResourceDeleteRequest);
+            Mockito.verify(streamObserver, Mockito.times(1)).onCompleted();
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testDeleteDropboxResourceFail() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        DropboxResourceDeleteRequest DropboxResourceDeleteRequest = Mockito.mock(DropboxResourceDeleteRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.deleteDropboxResource(DropboxResourceDeleteRequest)).thenReturn(false);
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+
+            resourceServiceHandler.deleteDropboxResource(DropboxResourceDeleteRequest, streamObserver);
+
+            Mockito.verify(resourceBackend, Mockito.times(1)).deleteDropboxResource(DropboxResourceDeleteRequest);
+            Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+            Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(Exception.class));
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testDeleteDropboxResource_CreateThrowsException() {
+        ResourceServiceHandler resourceServiceHandler = Mockito.spy(new ResourceServiceHandler());
+        DropboxResourceDeleteRequest DropboxResourceDeleteRequest = Mockito.mock(DropboxResourceDeleteRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        ResourceBackend resourceBackend = Mockito.mock(ResourceBackend.class);
+
+        try {
+            Mockito.when(resourceBackend.deleteDropboxResource(DropboxResourceDeleteRequest)).thenThrow(new Exception());
+            Mockito.doReturn(resourceBackend).when(resourceServiceHandler).getBackend();
+
+            resourceServiceHandler.deleteDropboxResource(DropboxResourceDeleteRequest, streamObserver);
+
+            Mockito.verify(resourceBackend, Mockito.times(1)).deleteDropboxResource(DropboxResourceDeleteRequest);
+            Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+            Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+}

--- a/services/resource-service/server/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/services/resource-service/server/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/services/secret-service/server/pom.xml
+++ b/services/secret-service/server/pom.xml
@@ -78,6 +78,19 @@
             <artifactId>json-simple</artifactId>
             <version>1.1.1</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.6.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.3.3</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/services/secret-service/server/src/main/java/org/apache/airavata/mft/secret/server/backend/file/FileBasedSecretBackend.java
+++ b/services/secret-service/server/src/main/java/org/apache/airavata/mft/secret/server/backend/file/FileBasedSecretBackend.java
@@ -17,6 +17,7 @@
 
 package org.apache.airavata.mft.secret.server.backend.file;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.airavata.mft.secret.server.backend.SecretBackend;
 import org.apache.airavata.mft.secret.service.*;
 import org.json.simple.JSONArray;
@@ -53,7 +54,7 @@ public class FileBasedSecretBackend implements SecretBackend {
     @Override
     public Optional<SCPSecret> getSCPSecret(SCPSecretGetRequest request) throws Exception {
         JSONParser jsonParser = new JSONParser();
-        InputStream inputStream = FileBasedSecretBackend.class.getClassLoader().getResourceAsStream(secretFile);
+        InputStream inputStream = FileBasedSecretBackend.class.getClassLoader().getResourceAsStream(getSecretFile());
 
         try (InputStreamReader reader = new InputStreamReader(inputStream)) {
             Object obj = jsonParser.parse(reader);
@@ -95,7 +96,7 @@ public class FileBasedSecretBackend implements SecretBackend {
     @Override
     public Optional<S3Secret> getS3Secret(S3SecretGetRequest request) throws Exception {
         JSONParser jsonParser = new JSONParser();
-        InputStream inputStream = FileBasedSecretBackend.class.getClassLoader().getResourceAsStream(secretFile);
+        InputStream inputStream = FileBasedSecretBackend.class.getClassLoader().getResourceAsStream(getSecretFile());
 
         try (InputStreamReader reader = new InputStreamReader(inputStream)) {
             Object obj = jsonParser.parse(reader);
@@ -136,7 +137,7 @@ public class FileBasedSecretBackend implements SecretBackend {
     @Override
     public Optional<BoxSecret> getBoxSecret(BoxSecretGetRequest request) throws Exception {
         JSONParser jsonParser = new JSONParser();
-        InputStream inputStream = FileBasedSecretBackend.class.getClassLoader().getResourceAsStream(secretFile);
+        InputStream inputStream = FileBasedSecretBackend.class.getClassLoader().getResourceAsStream(getSecretFile());
 
         try (InputStreamReader reader = new InputStreamReader(inputStream)) {
             Object obj = jsonParser.parse(reader);
@@ -177,7 +178,7 @@ public class FileBasedSecretBackend implements SecretBackend {
     @Override
     public Optional<AzureSecret> getAzureSecret(AzureSecretGetRequest request) throws Exception {
         JSONParser jsonParser = new JSONParser();
-        InputStream inputStream = FileBasedSecretBackend.class.getClassLoader().getResourceAsStream(secretFile);
+        InputStream inputStream = FileBasedSecretBackend.class.getClassLoader().getResourceAsStream(getSecretFile());
 
         try (InputStreamReader reader = new InputStreamReader(inputStream)) {
             Object obj = jsonParser.parse(reader);
@@ -217,7 +218,7 @@ public class FileBasedSecretBackend implements SecretBackend {
     @Override
     public Optional<GCSSecret> getGCSSecret(GCSSecretGetRequest request) throws Exception {
         JSONParser jsonParser = new JSONParser();
-        InputStream inputStream = FileBasedSecretBackend.class.getClassLoader().getResourceAsStream(secretFile);
+        InputStream inputStream = FileBasedSecretBackend.class.getClassLoader().getResourceAsStream(getSecretFile());
 
         try (InputStreamReader reader = new InputStreamReader(inputStream)) {
             Object obj = jsonParser.parse(reader);
@@ -256,7 +257,7 @@ public class FileBasedSecretBackend implements SecretBackend {
     @Override
     public Optional<DropboxSecret> getDropboxSecret(DropboxSecretGetRequest request) throws Exception {
         JSONParser jsonParser = new JSONParser();
-        InputStream inputStream = FileBasedSecretBackend.class.getClassLoader().getResourceAsStream(secretFile);
+        InputStream inputStream = FileBasedSecretBackend.class.getClassLoader().getResourceAsStream(getSecretFile());
 
         try (InputStreamReader reader = new InputStreamReader(inputStream)) {
             Object obj = jsonParser.parse(reader);
@@ -292,5 +293,8 @@ public class FileBasedSecretBackend implements SecretBackend {
         throw new UnsupportedOperationException("Operation is not supported in backend");
     }
 
-
+    @VisibleForTesting
+    protected String getSecretFile() {
+        return secretFile;
+    }
 }

--- a/services/secret-service/server/src/main/java/org/apache/airavata/mft/secret/server/handler/SecretServiceHandler.java
+++ b/services/secret-service/server/src/main/java/org/apache/airavata/mft/secret/server/handler/SecretServiceHandler.java
@@ -17,6 +17,7 @@
 
 package org.apache.airavata.mft.secret.server.handler;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.Empty;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
@@ -38,7 +39,7 @@ public class SecretServiceHandler extends SecretServiceGrpc.SecretServiceImplBas
     @Override
     public void getSCPSecret(SCPSecretGetRequest request, StreamObserver<SCPSecret> responseObserver) {
         try {
-            this.backend.getSCPSecret(request).ifPresentOrElse(secret -> {
+            this.getBackend().getSCPSecret(request).ifPresentOrElse(secret -> {
                 responseObserver.onNext(secret);
                 responseObserver.onCompleted();
             }, () -> {
@@ -57,19 +58,19 @@ public class SecretServiceHandler extends SecretServiceGrpc.SecretServiceImplBas
 
     @Override
     public void createSCPSecret(SCPSecretCreateRequest request, StreamObserver<SCPSecret> responseObserver) {
-        responseObserver.onNext(this.backend.createSCPSecret(request));
+        responseObserver.onNext(this.getBackend().createSCPSecret(request));
         responseObserver.onCompleted();
     }
 
     @Override
     public void updateSCPSecret(SCPSecretUpdateRequest request, StreamObserver<Empty> responseObserver) {
-        this.backend.updateSCPSecret(request);
+        this.getBackend().updateSCPSecret(request);
         responseObserver.onCompleted();
     }
 
     @Override
     public void deleteSCPSecret(SCPSecretDeleteRequest request, StreamObserver<Empty> responseObserver) {
-        boolean res = this.backend.deleteSCPSecret(request);
+        boolean res = this.getBackend().deleteSCPSecret(request);
         if (res) {
             responseObserver.onCompleted();
         } else {
@@ -82,7 +83,7 @@ public class SecretServiceHandler extends SecretServiceGrpc.SecretServiceImplBas
     @Override
     public void getS3Secret(S3SecretGetRequest request, StreamObserver<S3Secret> responseObserver) {
         try {
-            this.backend.getS3Secret(request).ifPresentOrElse(secret -> {
+            this.getBackend().getS3Secret(request).ifPresentOrElse(secret -> {
                 responseObserver.onNext(secret);
                 responseObserver.onCompleted();
             }, () -> {
@@ -102,7 +103,7 @@ public class SecretServiceHandler extends SecretServiceGrpc.SecretServiceImplBas
     @Override
     public void createS3Secret(S3SecretCreateRequest request, StreamObserver<S3Secret> responseObserver) {
         try {
-            this.backend.createS3Secret(request);
+            this.getBackend().createS3Secret(request);
         } catch (Exception e) {
             logger.error("Error in creating S3 Secret", e);
             responseObserver.onError(Status.INTERNAL.withCause(e)
@@ -114,7 +115,7 @@ public class SecretServiceHandler extends SecretServiceGrpc.SecretServiceImplBas
     @Override
     public void updateS3Secret(S3SecretUpdateRequest request, StreamObserver<Empty> responseObserver) {
         try {
-            this.backend.updateS3Secret(request);
+            this.getBackend().updateS3Secret(request);
         } catch (Exception e) {
             logger.error("Error in updating S3 Secret with id {}", request.getSecretId(), e);
             responseObserver.onError(Status.INTERNAL.withCause(e)
@@ -126,7 +127,7 @@ public class SecretServiceHandler extends SecretServiceGrpc.SecretServiceImplBas
     @Override
     public void deleteS3Secret(S3SecretDeleteRequest request, StreamObserver<Empty> responseObserver) {
         try {
-            this.backend.deleteS3Secret(request);
+            this.getBackend().deleteS3Secret(request);
         } catch (Exception e) {
             logger.error("Error in deleting S3 Secret with id {}", request.getSecretId(), e);
             responseObserver.onError(Status.INTERNAL.withCause(e)
@@ -138,7 +139,7 @@ public class SecretServiceHandler extends SecretServiceGrpc.SecretServiceImplBas
     @Override
     public void getBoxSecret(BoxSecretGetRequest request, StreamObserver<BoxSecret> responseObserver) {
         try {
-            this.backend.getBoxSecret(request).ifPresentOrElse(secret -> {
+            this.getBackend().getBoxSecret(request).ifPresentOrElse(secret -> {
                 responseObserver.onNext(secret);
                 responseObserver.onCompleted();
             }, () -> {
@@ -159,7 +160,7 @@ public class SecretServiceHandler extends SecretServiceGrpc.SecretServiceImplBas
     @Override
     public void createBoxSecret(BoxSecretCreateRequest request, StreamObserver<BoxSecret> responseObserver) {
         try {
-            this.backend.createBoxSecret(request);
+            this.getBackend().createBoxSecret(request);
         } catch (Exception e) {
             logger.error("Error in creating Box Secret", e);
             responseObserver.onError(Status.INTERNAL.withCause(e)
@@ -171,7 +172,7 @@ public class SecretServiceHandler extends SecretServiceGrpc.SecretServiceImplBas
     @Override
     public void updateBoxSecret(BoxSecretUpdateRequest request, StreamObserver<Empty> responseObserver) {
         try {
-            this.backend.updateBoxSecret(request);
+            this.getBackend().updateBoxSecret(request);
         } catch (Exception e) {
             logger.error("Error in updating Box Secret with id {}", request.getSecretId(), e);
             responseObserver.onError(Status.INTERNAL.withCause(e)
@@ -183,7 +184,7 @@ public class SecretServiceHandler extends SecretServiceGrpc.SecretServiceImplBas
     @Override
     public void deleteBoxSecret(BoxSecretDeleteRequest request, StreamObserver<Empty> responseObserver) {
         try {
-            this.backend.deleteBoxSecret(request);
+            this.getBackend().deleteBoxSecret(request);
         } catch (Exception e) {
             logger.error("Error in deleting Box Secret with id {}", request.getSecretId(), e);
             responseObserver.onError(Status.INTERNAL.withCause(e)
@@ -195,7 +196,7 @@ public class SecretServiceHandler extends SecretServiceGrpc.SecretServiceImplBas
     @Override
     public void getAzureSecret(AzureSecretGetRequest request, StreamObserver<AzureSecret> responseObserver) {
         try {
-            this.backend.getAzureSecret(request).ifPresentOrElse(secret -> {
+            this.getBackend().getAzureSecret(request).ifPresentOrElse(secret -> {
                 responseObserver.onNext(secret);
                 responseObserver.onCompleted();
             }, () -> {
@@ -216,7 +217,7 @@ public class SecretServiceHandler extends SecretServiceGrpc.SecretServiceImplBas
     @Override
     public void createAzureSecret(AzureSecretCreateRequest request, StreamObserver<AzureSecret> responseObserver) {
         try {
-            this.backend.createAzureSecret(request);
+            this.getBackend().createAzureSecret(request);
         } catch (Exception e) {
             logger.error("Error in creating Azure Secret", e);
             responseObserver.onError(Status.INTERNAL.withCause(e)
@@ -228,7 +229,7 @@ public class SecretServiceHandler extends SecretServiceGrpc.SecretServiceImplBas
     @Override
     public void updateAzureSecret(AzureSecretUpdateRequest request, StreamObserver<Empty> responseObserver) {
         try {
-            this.backend.updateAzureSecret(request);
+            this.getBackend().updateAzureSecret(request);
         } catch (Exception e) {
             logger.error("Error in updating Azure Secret with id {}", request.getSecretId(), e);
             responseObserver.onError(Status.INTERNAL.withCause(e)
@@ -240,7 +241,7 @@ public class SecretServiceHandler extends SecretServiceGrpc.SecretServiceImplBas
     @Override
     public void deleteAzureSecret(AzureSecretDeleteRequest request, StreamObserver<Empty> responseObserver) {
         try {
-            this.backend.deleteAzureSecret(request);
+            this.getBackend().deleteAzureSecret(request);
         } catch (Exception e) {
             logger.error("Error in deleting Azure Secret with id {}", request.getSecretId(), e);
             responseObserver.onError(Status.INTERNAL.withCause(e)
@@ -254,7 +255,7 @@ public class SecretServiceHandler extends SecretServiceGrpc.SecretServiceImplBas
     @Override
     public void getGCSSecret(GCSSecretGetRequest request, StreamObserver<GCSSecret> responseObserver) {
         try {
-            this.backend.getGCSSecret(request).ifPresentOrElse(secret -> {
+            this.getBackend().getGCSSecret(request).ifPresentOrElse(secret -> {
                 responseObserver.onNext(secret);
                 responseObserver.onCompleted();
             }, () -> {
@@ -274,7 +275,7 @@ public class SecretServiceHandler extends SecretServiceGrpc.SecretServiceImplBas
     @Override
     public void createGCSSecret(GCSSecretCreateRequest request, StreamObserver<GCSSecret> responseObserver) {
         try {
-            this.backend.createGCSSecret(request);
+            this.getBackend().createGCSSecret(request);
         } catch (Exception e) {
             logger.error("Error in creating GCS Secret", e);
             responseObserver.onError(Status.INTERNAL.withCause(e)
@@ -286,7 +287,7 @@ public class SecretServiceHandler extends SecretServiceGrpc.SecretServiceImplBas
     @Override
     public void updateGCSSecret(GCSSecretUpdateRequest request, StreamObserver<Empty> responseObserver) {
         try {
-            this.backend.updateGCSSecret(request);
+            this.getBackend().updateGCSSecret(request);
         } catch (Exception e) {
             logger.error("Error in updating GCS Secret with id {}", request.getSecretId(), e);
             responseObserver.onError(Status.INTERNAL.withCause(e)
@@ -298,7 +299,7 @@ public class SecretServiceHandler extends SecretServiceGrpc.SecretServiceImplBas
     @Override
     public void deleteGCSSecret(GCSSecretDeleteRequest request, StreamObserver<Empty> responseObserver) {
         try {
-            this.backend.deleteGCSSecret(request);
+            this.getBackend().deleteGCSSecret(request);
         } catch (Exception e) {
             logger.error("Error in deleting GCS Secret with id {}", request.getSecretId(), e);
             responseObserver.onError(Status.INTERNAL.withCause(e)
@@ -312,7 +313,7 @@ public class SecretServiceHandler extends SecretServiceGrpc.SecretServiceImplBas
     @Override
     public void getDropboxSecret(DropboxSecretGetRequest request, StreamObserver<DropboxSecret> responseObserver) {
         try {
-            this.backend.getDropboxSecret(request).ifPresentOrElse(secret -> {
+            this.getBackend().getDropboxSecret(request).ifPresentOrElse(secret -> {
                 responseObserver.onNext(secret);
                 responseObserver.onCompleted();
             }, () -> {
@@ -332,7 +333,7 @@ public class SecretServiceHandler extends SecretServiceGrpc.SecretServiceImplBas
     @Override
     public void createDropboxSecret(DropboxSecretCreateRequest request, StreamObserver<DropboxSecret> responseObserver) {
         try {
-            this.backend.createDropboxSecret(request);
+            this.getBackend().createDropboxSecret(request);
         } catch (Exception e) {
             logger.error("Error in creating Dropbox Secret", e);
             responseObserver.onError(Status.INTERNAL.withCause(e)
@@ -344,7 +345,7 @@ public class SecretServiceHandler extends SecretServiceGrpc.SecretServiceImplBas
     @Override
     public void updateDropboxSecret(DropboxSecretUpdateRequest request, StreamObserver<Empty> responseObserver) {
         try {
-            this.backend.updateDropboxSecret(request);
+            this.getBackend().updateDropboxSecret(request);
         } catch (Exception e) {
             logger.error("Error in updating Dropbox Secret with id {}", request.getSecretId(), e);
             responseObserver.onError(Status.INTERNAL.withCause(e)
@@ -356,7 +357,7 @@ public class SecretServiceHandler extends SecretServiceGrpc.SecretServiceImplBas
     @Override
     public void deleteDropboxSecret(DropboxSecretDeleteRequest request, StreamObserver<Empty> responseObserver) {
         try {
-            this.backend.deleteDropboxSecret(request);
+            this.getBackend().deleteDropboxSecret(request);
         } catch (Exception e) {
             logger.error("Error in deleting Dropbox Secret with id {}", request.getSecretId(), e);
             responseObserver.onError(Status.INTERNAL.withCause(e)
@@ -365,5 +366,9 @@ public class SecretServiceHandler extends SecretServiceGrpc.SecretServiceImplBas
         }
     }
 
+    @VisibleForTesting
+    protected SecretBackend getBackend() {
+        return this.backend;
+    }
 
 }

--- a/services/secret-service/server/src/test/java/org/apache/airavata/mft/secret/server/backend/file/TestFileBasedSecretBackend.java
+++ b/services/secret-service/server/src/test/java/org/apache/airavata/mft/secret/server/backend/file/TestFileBasedSecretBackend.java
@@ -1,0 +1,210 @@
+package org.apache.airavata.mft.secret.server.backend.file;
+
+import org.apache.airavata.mft.secret.service.*;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TestFileBasedSecretBackend {
+
+    static FileBasedSecretBackend fileBasedSecretBackend;
+
+    @BeforeAll
+    public static void before() {
+        fileBasedSecretBackend = Mockito.spy(new FileBasedSecretBackend());
+        Mockito.doReturn("secrets.json").when(fileBasedSecretBackend).getSecretFile();
+    }
+
+    @Test
+    public void testGetSCPSecret_WithProperSecretId() {
+        SCPSecretGetRequest SecretGetRequest = Mockito.mock(SCPSecretGetRequest.class);
+        Mockito.when(SecretGetRequest.getSecretId()).thenReturn("WrongSecretId");
+
+        try {
+            assertTrue(fileBasedSecretBackend.getSCPSecret(SecretGetRequest).isEmpty());
+        } catch (Exception e) {
+            fail("Exception from connector: ", e);
+        }
+    }
+
+    @Test
+    public void testGetSCPSecret_WithWrongSecretId() {
+        String secretId = "local-ssh-cred";
+        SCPSecretGetRequest secretGetRequest = Mockito.mock(SCPSecretGetRequest.class);
+        Mockito.when(secretGetRequest.getSecretId()).thenReturn(secretId);
+
+        try {
+            Optional<SCPSecret> scpSecretOptional = fileBasedSecretBackend.getSCPSecret(secretGetRequest);
+            assertTrue(scpSecretOptional.isPresent());
+
+            SCPSecret scpSecret = scpSecretOptional.get();
+            assertEquals(secretId, scpSecret.getSecretId());
+            assertNotNull(scpSecret.getSecretId());
+            assertNotNull(scpSecret.getPrivateKey());
+            assertNotNull(scpSecret.getPublicKey());
+            assertNotNull(scpSecret.getPassphrase());
+        } catch (Exception e) {
+            fail("Exception from connector: ", e);
+        }
+    }
+
+    @Test
+    public void testGetS3Secret_WithProperSecretId() {
+        S3SecretGetRequest SecretGetRequest = Mockito.mock(S3SecretGetRequest.class);
+        Mockito.when(SecretGetRequest.getSecretId()).thenReturn("WrongSecretId");
+
+        try {
+            assertTrue(fileBasedSecretBackend.getS3Secret(SecretGetRequest).isEmpty());
+        } catch (Exception e) {
+            fail("Exception from connector: ", e);
+        }
+    }
+
+    @Test
+    public void testGetS3Secret_WithWrongSecretId() {
+        String SecretId = "s3-cred";
+        S3SecretGetRequest SecretGetRequest = Mockito.mock(S3SecretGetRequest.class);
+        Mockito.when(SecretGetRequest.getSecretId()).thenReturn(SecretId);
+
+        try {
+            Optional<S3Secret> s3SecretOptional = fileBasedSecretBackend.getS3Secret(SecretGetRequest);
+            assertTrue(s3SecretOptional.isPresent());
+
+            S3Secret s3Secret = s3SecretOptional.get();
+            assertEquals(SecretId, s3Secret.getSecretId());
+            assertNotNull(s3Secret.getSecretId());
+            assertNotNull(s3Secret.getAccessKey());
+            assertNotNull(s3Secret.getSecretKey());
+        } catch (Exception e) {
+            fail("Exception from connector: ", e);
+        }
+    }
+
+    @Test
+    public void testGetBoxSecret_WithProperSecretId() {
+        BoxSecretGetRequest SecretGetRequest = Mockito.mock(BoxSecretGetRequest.class);
+        Mockito.when(SecretGetRequest.getSecretId()).thenReturn("WrongSecretId");
+
+        try {
+            assertTrue(fileBasedSecretBackend.getBoxSecret(SecretGetRequest).isEmpty());
+        } catch (Exception e) {
+            fail("Exception from connector: ", e);
+        }
+    }
+
+    @Test
+    public void testGetBoxSecret_WithWrongSecretId() {
+        String SecretId = "box-cred";
+        BoxSecretGetRequest SecretGetRequest = Mockito.mock(BoxSecretGetRequest.class);
+        Mockito.when(SecretGetRequest.getSecretId()).thenReturn(SecretId);
+
+        try {
+            Optional<BoxSecret> boxSecretOptional = fileBasedSecretBackend.getBoxSecret(SecretGetRequest);
+            assertTrue(boxSecretOptional.isPresent());
+
+            BoxSecret boxSecret = boxSecretOptional.get();
+            assertEquals(SecretId, boxSecret.getSecretId());
+            assertNotNull(boxSecret.getAccessToken());
+        } catch (Exception e) {
+            fail("Exception from connector: ", e);
+        }
+    }
+
+    @Test
+    public void testGetAzureSecret_WithProperSecretId() {
+        AzureSecretGetRequest SecretGetRequest = Mockito.mock(AzureSecretGetRequest.class);
+        Mockito.when(SecretGetRequest.getSecretId()).thenReturn("WrongSecretId");
+
+        try {
+            assertTrue(fileBasedSecretBackend.getAzureSecret(SecretGetRequest).isEmpty());
+        } catch (Exception e) {
+            fail("Exception from connector: ", e);
+        }
+    }
+
+    @Test
+    public void testGetAzureSecret_WithWrongSecretId() {
+        String SecretId = "azure-cred";
+        AzureSecretGetRequest SecretGetRequest = Mockito.mock(AzureSecretGetRequest.class);
+        Mockito.when(SecretGetRequest.getSecretId()).thenReturn(SecretId);
+
+        try {
+            Optional<AzureSecret> azureSecretOptional = fileBasedSecretBackend.getAzureSecret(SecretGetRequest);
+            assertTrue(azureSecretOptional.isPresent());
+
+            AzureSecret azureSecret = azureSecretOptional.get();
+            assertEquals(SecretId, azureSecret.getSecretId());
+            assertNotNull(azureSecret.getSecretId());
+            assertNotNull(azureSecret.getConnectionString());
+        } catch (Exception e) {
+            fail("Exception from connector: ", e);
+        }
+    }
+
+    @Test
+    public void testGetGCSSecret_WithProperSecretId() {
+        GCSSecretGetRequest SecretGetRequest = Mockito.mock(GCSSecretGetRequest.class);
+        Mockito.when(SecretGetRequest.getSecretId()).thenReturn("WrongSecretId");
+
+        try {
+            assertTrue(fileBasedSecretBackend.getGCSSecret(SecretGetRequest).isEmpty());
+        } catch (Exception e) {
+            fail("Exception from connector: ", e);
+        }
+    }
+
+    @Test
+    public void testGetGCSSecret_WithWrongSecretId() {
+        String SecretId = "gcs-cred";
+        GCSSecretGetRequest SecretGetRequest = Mockito.mock(GCSSecretGetRequest.class);
+        Mockito.when(SecretGetRequest.getSecretId()).thenReturn(SecretId);
+
+        try {
+            Optional<GCSSecret> gcsSecretOptional = fileBasedSecretBackend.getGCSSecret(SecretGetRequest);
+            assertTrue(gcsSecretOptional.isPresent());
+
+            GCSSecret gcsSecret = gcsSecretOptional.get();
+            assertEquals(SecretId, gcsSecret.getSecretId());
+            assertNotNull(gcsSecret.getSecretId());
+            assertNotNull(gcsSecret.getCredentialsJson());
+        } catch (Exception e) {
+            fail("Exception from connector: ", e);
+        }
+    }
+
+    @Test
+    public void testGetDropboxSecret_WithProperSecretId() {
+        DropboxSecretGetRequest SecretGetRequest = Mockito.mock(DropboxSecretGetRequest.class);
+        Mockito.when(SecretGetRequest.getSecretId()).thenReturn("WrongSecretId");
+
+        try {
+            assertTrue(fileBasedSecretBackend.getDropboxSecret(SecretGetRequest).isEmpty());
+        } catch (Exception e) {
+            fail("Exception from connector: ", e);
+        }
+    }
+
+    @Test
+    public void testGetDropboxSecret_WithWrongSecretId() {
+        String SecretId = "dropbox-cred";
+        DropboxSecretGetRequest SecretGetRequest = Mockito.mock(DropboxSecretGetRequest.class);
+        Mockito.when(SecretGetRequest.getSecretId()).thenReturn(SecretId);
+
+        try {
+            Optional<DropboxSecret> dropboxSecretOptional = fileBasedSecretBackend.getDropboxSecret(SecretGetRequest);
+            assertTrue(dropboxSecretOptional.isPresent());
+
+            DropboxSecret dropboxSecret = dropboxSecretOptional.get();
+            assertEquals(SecretId, dropboxSecret.getSecretId());
+            assertNotNull(dropboxSecret.getSecretId());
+            assertNotNull(dropboxSecret.getAccessToken());
+        } catch (Exception e) {
+            fail("Exception from connector: ", e);
+        }
+    }
+
+}

--- a/services/secret-service/server/src/test/java/org/apache/airavata/mft/secret/server/handler/TestSecretServiceHandler.java
+++ b/services/secret-service/server/src/test/java/org/apache/airavata/mft/secret/server/handler/TestSecretServiceHandler.java
@@ -1,0 +1,1082 @@
+package org.apache.airavata.mft.secret.server.handler;
+
+import com.google.protobuf.Empty;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.StreamObserver;
+import org.apache.airavata.mft.secret.service.*;
+import org.apache.airavata.mft.secret.server.backend.SecretBackend;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class TestSecretServiceHandler {
+
+    @Test
+    public void testGetScpSecret() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        SCPSecretGetRequest scpSecretGetRequest = Mockito.mock(SCPSecretGetRequest.class);
+        StreamObserver<SCPSecret> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+        SCPSecret scpSecret = Mockito.mock(SCPSecret.class);
+
+        try {
+            Mockito.when(secretBackend.getSCPSecret(scpSecretGetRequest)).thenReturn(Optional.of(scpSecret));
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        secretServiceHandler.getSCPSecret(scpSecretGetRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(1)).onNext(scpSecret);
+        Mockito.verify(streamObserver, Mockito.times(1)).onCompleted();
+    }
+
+    @Test
+    public void testGetScpSecret_EmptySecret() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        SCPSecretGetRequest scpSecretGetRequest = Mockito.mock(SCPSecretGetRequest.class);
+        StreamObserver<SCPSecret> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+
+        try {
+            Mockito.when(secretBackend.getSCPSecret(scpSecretGetRequest)).thenReturn(Optional.empty());
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        secretServiceHandler.getSCPSecret(scpSecretGetRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(0)).onNext(Mockito.any(SCPSecret.class));
+        Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+        Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+    }
+
+    @Test
+    public void testGetScpSecret_SCPSecretThrowsError() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        SCPSecretGetRequest scpSecretGetRequest = Mockito.mock(SCPSecretGetRequest.class);
+        StreamObserver<SCPSecret> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+
+        try {
+            Mockito.when(secretBackend.getSCPSecret(scpSecretGetRequest)).thenThrow(new Exception());
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        secretServiceHandler.getSCPSecret(scpSecretGetRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(0)).onNext(Mockito.any(SCPSecret.class));
+        Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+        Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+    }
+
+    @Test
+    public void testCreateScpSecret() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        SCPSecretCreateRequest scpSecretCreateRequest = Mockito.mock(SCPSecretCreateRequest.class);
+        StreamObserver<SCPSecret> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+        SCPSecret scpSecret = Mockito.mock(SCPSecret.class);
+
+        try {
+            Mockito.when(secretBackend.createSCPSecret(scpSecretCreateRequest)).thenReturn(scpSecret);
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        secretServiceHandler.createSCPSecret(scpSecretCreateRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(1)).onNext(scpSecret);
+        Mockito.verify(streamObserver, Mockito.times(1)).onCompleted();
+    }
+
+    @Test
+    public void testUpdateScpSecret() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        SCPSecretUpdateRequest scpSecretUpdateRequest = Mockito.mock(SCPSecretUpdateRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+
+        try {
+            Mockito.when(secretBackend.updateSCPSecret(scpSecretUpdateRequest)).thenReturn(false);
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+
+            secretServiceHandler.updateSCPSecret(scpSecretUpdateRequest, streamObserver);
+
+            Mockito.verify(secretBackend, Mockito.times(1)).updateSCPSecret(scpSecretUpdateRequest);
+            Mockito.verify(streamObserver, Mockito.times(1)).onCompleted();
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testDeleteScpSecretSuccessful() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        SCPSecretDeleteRequest scpSecretDeleteRequest = Mockito.mock(SCPSecretDeleteRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+
+        try {
+            Mockito.when(secretBackend.deleteSCPSecret(scpSecretDeleteRequest)).thenReturn(true);
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+
+            secretServiceHandler.deleteSCPSecret(scpSecretDeleteRequest, streamObserver);
+
+            Mockito.verify(secretBackend, Mockito.times(1)).deleteSCPSecret(scpSecretDeleteRequest);
+            Mockito.verify(streamObserver, Mockito.times(1)).onCompleted();
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testDeleteScpSecretFail() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        SCPSecretDeleteRequest scpSecretDeleteRequest = Mockito.mock(SCPSecretDeleteRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+
+        try {
+            Mockito.when(secretBackend.deleteSCPSecret(scpSecretDeleteRequest)).thenReturn(false);
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+
+            secretServiceHandler.deleteSCPSecret(scpSecretDeleteRequest, streamObserver);
+
+            Mockito.verify(secretBackend, Mockito.times(1)).deleteSCPSecret(scpSecretDeleteRequest);
+            Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+            Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testGetS3Secret() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        S3SecretGetRequest secretRequest = Mockito.mock(S3SecretGetRequest.class);
+        StreamObserver<S3Secret> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+        S3Secret scpSecret = Mockito.mock(S3Secret.class);
+
+        try {
+            Mockito.when(secretBackend.getS3Secret(secretRequest)).thenReturn(Optional.of(scpSecret));
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        secretServiceHandler.getS3Secret(secretRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(1)).onNext(scpSecret);
+        Mockito.verify(streamObserver, Mockito.times(1)).onCompleted();
+    }
+
+    @Test
+    public void testGetS3Secret_EmptySecret() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        S3SecretGetRequest s3SecretGetRequest = Mockito.mock(S3SecretGetRequest.class);
+        StreamObserver<S3Secret> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+
+        try {
+            Mockito.when(secretBackend.getS3Secret(s3SecretGetRequest)).thenReturn(Optional.empty());
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        secretServiceHandler.getS3Secret(s3SecretGetRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(0)).onNext(Mockito.any(S3Secret.class));
+        Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+        Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+    }
+
+    @Test
+    public void testGetS3Secret_SCPSecretThrowsError() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        S3SecretGetRequest s3SecretGetRequest = Mockito.mock(S3SecretGetRequest.class);
+        StreamObserver<S3Secret> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+
+        try {
+            Mockito.when(secretBackend.getS3Secret(s3SecretGetRequest)).thenThrow(new Exception());
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        secretServiceHandler.getS3Secret(s3SecretGetRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(0)).onNext(Mockito.any(S3Secret.class));
+        Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+        Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+    }
+
+    @Test
+    public void testCreateS3Secret() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        S3SecretCreateRequest s3SecretCreateRequest = Mockito.mock(S3SecretCreateRequest.class);
+        StreamObserver<S3Secret> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+        S3Secret S3Secret = Mockito.mock(S3Secret.class);
+
+        try {
+            Mockito.when(secretBackend.createS3Secret(s3SecretCreateRequest)).thenReturn(S3Secret);
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+
+            secretServiceHandler.createS3Secret(s3SecretCreateRequest, streamObserver);
+
+            Mockito.verify(secretBackend, Mockito.times(1)).createS3Secret(s3SecretCreateRequest);
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testCreateS3Secret_CreateThrowsException() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        S3SecretCreateRequest s3SecretCreateRequest = Mockito.mock(S3SecretCreateRequest.class);
+        StreamObserver<S3Secret> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+        S3Secret S3Secret = Mockito.mock(S3Secret.class);
+
+        try {
+            Mockito.when(secretBackend.createS3Secret(s3SecretCreateRequest)).thenThrow(new Exception());
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        secretServiceHandler.createS3Secret(s3SecretCreateRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(0)).onNext(S3Secret);
+        Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+        Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+    }
+
+    @Test
+    public void testUpdateS3Secret() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        S3SecretUpdateRequest s3SecretUpdateRequest = Mockito.mock(S3SecretUpdateRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+
+        try {
+            Mockito.when(secretBackend.updateS3Secret(s3SecretUpdateRequest)).thenReturn(false);
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+
+            secretServiceHandler.updateS3Secret(s3SecretUpdateRequest, streamObserver);
+
+            Mockito.verify(secretBackend, Mockito.times(1)).updateS3Secret(s3SecretUpdateRequest);
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testUpdateS3Secret_CreateThrowsException() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        S3SecretUpdateRequest s3SecretUpdateRequest = Mockito.mock(S3SecretUpdateRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+
+        try {
+            Mockito.when(secretBackend.updateS3Secret(s3SecretUpdateRequest)).thenThrow(new Exception());
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+
+            secretServiceHandler.updateS3Secret(s3SecretUpdateRequest, streamObserver);
+
+            Mockito.verify(secretBackend, Mockito.times(1)).updateS3Secret(s3SecretUpdateRequest);
+            Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+            Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testDeleteS3SecretSuccessful() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        S3SecretDeleteRequest s3SecretDeleteRequest = Mockito.mock(S3SecretDeleteRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+
+        try {
+            Mockito.when(secretBackend.deleteS3Secret(s3SecretDeleteRequest)).thenReturn(true);
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+
+            secretServiceHandler.deleteS3Secret(s3SecretDeleteRequest, streamObserver);
+
+            Mockito.verify(secretBackend, Mockito.times(1)).deleteS3Secret(s3SecretDeleteRequest);
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testDeleteS3Secret_CreateThrowsException() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        S3SecretDeleteRequest s3SecretDeleteRequest = Mockito.mock(S3SecretDeleteRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+
+        try {
+            Mockito.when(secretBackend.deleteS3Secret(s3SecretDeleteRequest)).thenThrow(new Exception());
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+
+            secretServiceHandler.deleteS3Secret(s3SecretDeleteRequest, streamObserver);
+
+            Mockito.verify(secretBackend, Mockito.times(1)).deleteS3Secret(s3SecretDeleteRequest);
+            Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+            Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testGetBoxSecret() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        BoxSecretGetRequest secretRequest = Mockito.mock(BoxSecretGetRequest.class);
+        StreamObserver<BoxSecret> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+        BoxSecret scpSecret = Mockito.mock(BoxSecret.class);
+
+        try {
+            Mockito.when(secretBackend.getBoxSecret(secretRequest)).thenReturn(Optional.of(scpSecret));
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        secretServiceHandler.getBoxSecret(secretRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(1)).onNext(scpSecret);
+        Mockito.verify(streamObserver, Mockito.times(1)).onCompleted();
+    }
+
+    @Test
+    public void testGetBoxSecret_EmptySecret() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        BoxSecretGetRequest boxSecretGetRequest = Mockito.mock(BoxSecretGetRequest.class);
+        StreamObserver<BoxSecret> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+
+        try {
+            Mockito.when(secretBackend.getBoxSecret(boxSecretGetRequest)).thenReturn(Optional.empty());
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        secretServiceHandler.getBoxSecret(boxSecretGetRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(0)).onNext(Mockito.any(BoxSecret.class));
+        Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+        Mockito.verify(streamObserver, Mockito.times(2)).onError(Mockito.any(StatusRuntimeException.class));
+    }
+
+    @Test
+    public void testGetBoxSecret_SCPSecretThrowsError() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        BoxSecretGetRequest boxSecretGetRequest = Mockito.mock(BoxSecretGetRequest.class);
+        StreamObserver<BoxSecret> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+
+        try {
+            Mockito.when(secretBackend.getBoxSecret(boxSecretGetRequest)).thenThrow(new Exception());
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        secretServiceHandler.getBoxSecret(boxSecretGetRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(0)).onNext(Mockito.any(BoxSecret.class));
+        Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+        Mockito.verify(streamObserver, Mockito.times(2)).onError(Mockito.any(StatusRuntimeException.class));
+    }
+
+    @Test
+    public void testCreateBoxSecret() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        BoxSecretCreateRequest boxSecretCreateRequest = Mockito.mock(BoxSecretCreateRequest.class);
+        StreamObserver<BoxSecret> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+        BoxSecret BoxSecret = Mockito.mock(BoxSecret.class);
+
+        try {
+            Mockito.when(secretBackend.createBoxSecret(boxSecretCreateRequest)).thenReturn(BoxSecret);
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+
+            secretServiceHandler.createBoxSecret(boxSecretCreateRequest, streamObserver);
+
+            Mockito.verify(secretBackend, Mockito.times(1)).createBoxSecret(boxSecretCreateRequest);
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testCreateBoxSecret_CreateThrowsException() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        BoxSecretCreateRequest boxSecretCreateRequest = Mockito.mock(BoxSecretCreateRequest.class);
+        StreamObserver<BoxSecret> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+        BoxSecret BoxSecret = Mockito.mock(BoxSecret.class);
+
+        try {
+            Mockito.when(secretBackend.createBoxSecret(boxSecretCreateRequest)).thenThrow(new Exception());
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        secretServiceHandler.createBoxSecret(boxSecretCreateRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(0)).onNext(BoxSecret);
+        Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+        Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+    }
+
+    @Test
+    public void testUpdateBoxSecret() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        BoxSecretUpdateRequest boxSecretUpdateRequest = Mockito.mock(BoxSecretUpdateRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+
+        try {
+            Mockito.when(secretBackend.updateBoxSecret(boxSecretUpdateRequest)).thenReturn(false);
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+
+            secretServiceHandler.updateBoxSecret(boxSecretUpdateRequest, streamObserver);
+
+            Mockito.verify(secretBackend, Mockito.times(1)).updateBoxSecret(boxSecretUpdateRequest);
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testUpdateBoxSecret_CreateThrowsException() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        BoxSecretUpdateRequest boxSecretUpdateRequest = Mockito.mock(BoxSecretUpdateRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+
+        try {
+            Mockito.when(secretBackend.updateBoxSecret(boxSecretUpdateRequest)).thenThrow(new Exception());
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+
+            secretServiceHandler.updateBoxSecret(boxSecretUpdateRequest, streamObserver);
+
+            Mockito.verify(secretBackend, Mockito.times(1)).updateBoxSecret(boxSecretUpdateRequest);
+            Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+            Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testDeleteBoxSecretSuccessful() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        BoxSecretDeleteRequest boxSecretDeleteRequest = Mockito.mock(BoxSecretDeleteRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+
+        try {
+            Mockito.when(secretBackend.deleteBoxSecret(boxSecretDeleteRequest)).thenReturn(true);
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+
+            secretServiceHandler.deleteBoxSecret(boxSecretDeleteRequest, streamObserver);
+
+            Mockito.verify(secretBackend, Mockito.times(1)).deleteBoxSecret(boxSecretDeleteRequest);
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testDeleteBoxSecret_CreateThrowsException() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        BoxSecretDeleteRequest boxSecretDeleteRequest = Mockito.mock(BoxSecretDeleteRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+
+        try {
+            Mockito.when(secretBackend.deleteBoxSecret(boxSecretDeleteRequest)).thenThrow(new Exception());
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+
+            secretServiceHandler.deleteBoxSecret(boxSecretDeleteRequest, streamObserver);
+
+            Mockito.verify(secretBackend, Mockito.times(1)).deleteBoxSecret(boxSecretDeleteRequest);
+            Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testGetAzureSecret() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        AzureSecretGetRequest secretRequest = Mockito.mock(AzureSecretGetRequest.class);
+        StreamObserver<AzureSecret> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+        AzureSecret scpSecret = Mockito.mock(AzureSecret.class);
+
+        try {
+            Mockito.when(secretBackend.getAzureSecret(secretRequest)).thenReturn(Optional.of(scpSecret));
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        secretServiceHandler.getAzureSecret(secretRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(1)).onNext(scpSecret);
+        Mockito.verify(streamObserver, Mockito.times(1)).onCompleted();
+    }
+
+    @Test
+    public void testGetAzureSecret_EmptySecret() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        AzureSecretGetRequest azureSecretGetRequest = Mockito.mock(AzureSecretGetRequest.class);
+        StreamObserver<AzureSecret> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+
+        try {
+            Mockito.when(secretBackend.getAzureSecret(azureSecretGetRequest)).thenReturn(Optional.empty());
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        secretServiceHandler.getAzureSecret(azureSecretGetRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(0)).onNext(Mockito.any(AzureSecret.class));
+        Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+        Mockito.verify(streamObserver, Mockito.times(2)).onError(Mockito.any(StatusRuntimeException.class));
+    }
+
+    @Test
+    public void testGetAzureSecret_SCPSecretThrowsError() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        AzureSecretGetRequest azureSecretGetRequest = Mockito.mock(AzureSecretGetRequest.class);
+        StreamObserver<AzureSecret> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+
+        try {
+            Mockito.when(secretBackend.getAzureSecret(azureSecretGetRequest)).thenThrow(new Exception());
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        secretServiceHandler.getAzureSecret(azureSecretGetRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(0)).onNext(Mockito.any(AzureSecret.class));
+        Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+        Mockito.verify(streamObserver, Mockito.times(2)).onError(Mockito.any(StatusRuntimeException.class));
+    }
+
+    @Test
+    public void testCreateAzureSecret() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        AzureSecretCreateRequest azureSecretCreateRequest = Mockito.mock(AzureSecretCreateRequest.class);
+        StreamObserver<AzureSecret> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+        AzureSecret AzureSecret = Mockito.mock(AzureSecret.class);
+
+        try {
+            Mockito.when(secretBackend.createAzureSecret(azureSecretCreateRequest)).thenReturn(AzureSecret);
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+
+            secretServiceHandler.createAzureSecret(azureSecretCreateRequest, streamObserver);
+
+            Mockito.verify(secretBackend, Mockito.times(1)).createAzureSecret(azureSecretCreateRequest);
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testCreateAzureSecret_CreateThrowsException() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        AzureSecretCreateRequest azureSecretCreateRequest = Mockito.mock(AzureSecretCreateRequest.class);
+        StreamObserver<AzureSecret> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+        AzureSecret AzureSecret = Mockito.mock(AzureSecret.class);
+
+        try {
+            Mockito.when(secretBackend.createAzureSecret(azureSecretCreateRequest)).thenThrow(new Exception());
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        secretServiceHandler.createAzureSecret(azureSecretCreateRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(0)).onNext(AzureSecret);
+        Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+        Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+    }
+
+    @Test
+    public void testUpdateAzureSecret() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        AzureSecretUpdateRequest azureSecretUpdateRequest = Mockito.mock(AzureSecretUpdateRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+
+        try {
+            Mockito.when(secretBackend.updateAzureSecret(azureSecretUpdateRequest)).thenReturn(false);
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+
+            secretServiceHandler.updateAzureSecret(azureSecretUpdateRequest, streamObserver);
+
+            Mockito.verify(secretBackend, Mockito.times(1)).updateAzureSecret(azureSecretUpdateRequest);
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testUpdateAzureSecret_CreateThrowsException() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        AzureSecretUpdateRequest azureSecretUpdateRequest = Mockito.mock(AzureSecretUpdateRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+
+        try {
+            Mockito.when(secretBackend.updateAzureSecret(azureSecretUpdateRequest)).thenThrow(new Exception());
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+
+            secretServiceHandler.updateAzureSecret(azureSecretUpdateRequest, streamObserver);
+
+            Mockito.verify(secretBackend, Mockito.times(1)).updateAzureSecret(azureSecretUpdateRequest);
+            Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+            Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testDeleteAzureSecretSuccessful() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        AzureSecretDeleteRequest azureSecretDeleteRequest = Mockito.mock(AzureSecretDeleteRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+
+        try {
+            Mockito.when(secretBackend.deleteAzureSecret(azureSecretDeleteRequest)).thenReturn(true);
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+
+            secretServiceHandler.deleteAzureSecret(azureSecretDeleteRequest, streamObserver);
+
+            Mockito.verify(secretBackend, Mockito.times(1)).deleteAzureSecret(azureSecretDeleteRequest);
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testDeleteAzureSecret_CreateThrowsException() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        AzureSecretDeleteRequest azureSecretDeleteRequest = Mockito.mock(AzureSecretDeleteRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+
+        try {
+            Mockito.when(secretBackend.deleteAzureSecret(azureSecretDeleteRequest)).thenThrow(new Exception());
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+
+            secretServiceHandler.deleteAzureSecret(azureSecretDeleteRequest, streamObserver);
+
+            Mockito.verify(secretBackend, Mockito.times(1)).deleteAzureSecret(azureSecretDeleteRequest);
+            Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testGetGCSSecret() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        GCSSecretGetRequest secretRequest = Mockito.mock(GCSSecretGetRequest.class);
+        StreamObserver<GCSSecret> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+        GCSSecret scpSecret = Mockito.mock(GCSSecret.class);
+
+        try {
+            Mockito.when(secretBackend.getGCSSecret(secretRequest)).thenReturn(Optional.of(scpSecret));
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        secretServiceHandler.getGCSSecret(secretRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(1)).onNext(scpSecret);
+        Mockito.verify(streamObserver, Mockito.times(1)).onCompleted();
+    }
+
+    @Test
+    public void testGetGCSSecret_EmptySecret() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        GCSSecretGetRequest gcsSecretGetRequest = Mockito.mock(GCSSecretGetRequest.class);
+        StreamObserver<GCSSecret> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+
+        try {
+            Mockito.when(secretBackend.getGCSSecret(gcsSecretGetRequest)).thenReturn(Optional.empty());
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        secretServiceHandler.getGCSSecret(gcsSecretGetRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(0)).onNext(Mockito.any(GCSSecret.class));
+        Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+        Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+    }
+
+    @Test
+    public void testGetGCSSecret_SCPSecretThrowsError() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        GCSSecretGetRequest gcsSecretGetRequest = Mockito.mock(GCSSecretGetRequest.class);
+        StreamObserver<GCSSecret> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+
+        try {
+            Mockito.when(secretBackend.getGCSSecret(gcsSecretGetRequest)).thenThrow(new Exception());
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        secretServiceHandler.getGCSSecret(gcsSecretGetRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(0)).onNext(Mockito.any(GCSSecret.class));
+        Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+        Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+    }
+
+    @Test
+    public void testCreateGCSSecret() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        GCSSecretCreateRequest gcsSecretCreateRequest = Mockito.mock(GCSSecretCreateRequest.class);
+        StreamObserver<GCSSecret> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+        GCSSecret GCSSecret = Mockito.mock(GCSSecret.class);
+
+        try {
+            Mockito.when(secretBackend.createGCSSecret(gcsSecretCreateRequest)).thenReturn(GCSSecret);
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+
+            secretServiceHandler.createGCSSecret(gcsSecretCreateRequest, streamObserver);
+
+            Mockito.verify(secretBackend, Mockito.times(1)).createGCSSecret(gcsSecretCreateRequest);
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testCreateGCSSecret_CreateThrowsException() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        GCSSecretCreateRequest gcsSecretCreateRequest = Mockito.mock(GCSSecretCreateRequest.class);
+        StreamObserver<GCSSecret> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+        GCSSecret GCSSecret = Mockito.mock(GCSSecret.class);
+
+        try {
+            Mockito.when(secretBackend.createGCSSecret(gcsSecretCreateRequest)).thenThrow(new Exception());
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        secretServiceHandler.createGCSSecret(gcsSecretCreateRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(0)).onNext(GCSSecret);
+        Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+        Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+    }
+
+    @Test
+    public void testUpdateGCSSecret() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        GCSSecretUpdateRequest gcsSecretUpdateRequest = Mockito.mock(GCSSecretUpdateRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+
+        try {
+            Mockito.when(secretBackend.updateGCSSecret(gcsSecretUpdateRequest)).thenReturn(false);
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+
+            secretServiceHandler.updateGCSSecret(gcsSecretUpdateRequest, streamObserver);
+
+            Mockito.verify(secretBackend, Mockito.times(1)).updateGCSSecret(gcsSecretUpdateRequest);
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testUpdateGCSSecret_CreateThrowsException() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        GCSSecretUpdateRequest gcsSecretUpdateRequest = Mockito.mock(GCSSecretUpdateRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+
+        try {
+            Mockito.when(secretBackend.updateGCSSecret(gcsSecretUpdateRequest)).thenThrow(new Exception());
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+
+            secretServiceHandler.updateGCSSecret(gcsSecretUpdateRequest, streamObserver);
+
+            Mockito.verify(secretBackend, Mockito.times(1)).updateGCSSecret(gcsSecretUpdateRequest);
+            Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+            Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testDeleteGCSSecretSuccessful() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        GCSSecretDeleteRequest gcsSecretDeleteRequest = Mockito.mock(GCSSecretDeleteRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+
+        try {
+            Mockito.when(secretBackend.deleteGCSSecret(gcsSecretDeleteRequest)).thenReturn(true);
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+
+            secretServiceHandler.deleteGCSSecret(gcsSecretDeleteRequest, streamObserver);
+
+            Mockito.verify(secretBackend, Mockito.times(1)).deleteGCSSecret(gcsSecretDeleteRequest);
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testDeleteGCSSecret_CreateThrowsException() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        GCSSecretDeleteRequest gcsSecretDeleteRequest = Mockito.mock(GCSSecretDeleteRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+
+        try {
+            Mockito.when(secretBackend.deleteGCSSecret(gcsSecretDeleteRequest)).thenThrow(new Exception());
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+
+            secretServiceHandler.deleteGCSSecret(gcsSecretDeleteRequest, streamObserver);
+
+            Mockito.verify(secretBackend, Mockito.times(1)).deleteGCSSecret(gcsSecretDeleteRequest);
+            Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testGetDropboxSecret() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        DropboxSecretGetRequest secretRequest = Mockito.mock(DropboxSecretGetRequest.class);
+        StreamObserver<DropboxSecret> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+        DropboxSecret scpSecret = Mockito.mock(DropboxSecret.class);
+
+        try {
+            Mockito.when(secretBackend.getDropboxSecret(secretRequest)).thenReturn(Optional.of(scpSecret));
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        secretServiceHandler.getDropboxSecret(secretRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(1)).onNext(scpSecret);
+        Mockito.verify(streamObserver, Mockito.times(1)).onCompleted();
+    }
+
+    @Test
+    public void testGetDropboxSecret_EmptySecret() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        DropboxSecretGetRequest dropboxSecretGetRequest = Mockito.mock(DropboxSecretGetRequest.class);
+        StreamObserver<DropboxSecret> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+
+        try {
+            Mockito.when(secretBackend.getDropboxSecret(dropboxSecretGetRequest)).thenReturn(Optional.empty());
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        secretServiceHandler.getDropboxSecret(dropboxSecretGetRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(0)).onNext(Mockito.any(DropboxSecret.class));
+        Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+        Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+    }
+
+    @Test
+    public void testGetDropboxSecret_SCPSecretThrowsError() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        DropboxSecretGetRequest dropboxSecretGetRequest = Mockito.mock(DropboxSecretGetRequest.class);
+        StreamObserver<DropboxSecret> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+
+        try {
+            Mockito.when(secretBackend.getDropboxSecret(dropboxSecretGetRequest)).thenThrow(new Exception());
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        secretServiceHandler.getDropboxSecret(dropboxSecretGetRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(0)).onNext(Mockito.any(DropboxSecret.class));
+        Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+        Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+    }
+
+    @Test
+    public void testCreateDropboxSecret() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        DropboxSecretCreateRequest dropboxSecretCreateRequest = Mockito.mock(DropboxSecretCreateRequest.class);
+        StreamObserver<DropboxSecret> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+        DropboxSecret DropboxSecret = Mockito.mock(DropboxSecret.class);
+
+        try {
+            Mockito.when(secretBackend.createDropboxSecret(dropboxSecretCreateRequest)).thenReturn(DropboxSecret);
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+
+            secretServiceHandler.createDropboxSecret(dropboxSecretCreateRequest, streamObserver);
+
+            Mockito.verify(secretBackend, Mockito.times(1)).createDropboxSecret(dropboxSecretCreateRequest);
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testCreateDropboxSecret_CreateThrowsException() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        DropboxSecretCreateRequest dropboxSecretCreateRequest = Mockito.mock(DropboxSecretCreateRequest.class);
+        StreamObserver<DropboxSecret> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+        DropboxSecret DropboxSecret = Mockito.mock(DropboxSecret.class);
+
+        try {
+            Mockito.when(secretBackend.createDropboxSecret(dropboxSecretCreateRequest)).thenThrow(new Exception());
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        secretServiceHandler.createDropboxSecret(dropboxSecretCreateRequest, streamObserver);
+
+        Mockito.verify(streamObserver, Mockito.times(0)).onNext(DropboxSecret);
+        Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+        Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+    }
+
+    @Test
+    public void testUpdateDropboxSecret() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        DropboxSecretUpdateRequest dropboxSecretUpdateRequest = Mockito.mock(DropboxSecretUpdateRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+
+        try {
+            Mockito.when(secretBackend.updateDropboxSecret(dropboxSecretUpdateRequest)).thenReturn(false);
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+
+            secretServiceHandler.updateDropboxSecret(dropboxSecretUpdateRequest, streamObserver);
+
+            Mockito.verify(secretBackend, Mockito.times(1)).updateDropboxSecret(dropboxSecretUpdateRequest);
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testUpdateDropboxSecret_CreateThrowsException() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        DropboxSecretUpdateRequest dropboxSecretUpdateRequest = Mockito.mock(DropboxSecretUpdateRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+
+        try {
+            Mockito.when(secretBackend.updateDropboxSecret(dropboxSecretUpdateRequest)).thenThrow(new Exception());
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+
+            secretServiceHandler.updateDropboxSecret(dropboxSecretUpdateRequest, streamObserver);
+
+            Mockito.verify(secretBackend, Mockito.times(1)).updateDropboxSecret(dropboxSecretUpdateRequest);
+            Mockito.verify(streamObserver, Mockito.times(0)).onCompleted();
+            Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testDeleteDropboxSecretSuccessful() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        DropboxSecretDeleteRequest dropboxSecretDeleteRequest = Mockito.mock(DropboxSecretDeleteRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+
+        try {
+            Mockito.when(secretBackend.deleteDropboxSecret(dropboxSecretDeleteRequest)).thenReturn(true);
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+
+            secretServiceHandler.deleteDropboxSecret(dropboxSecretDeleteRequest, streamObserver);
+
+            Mockito.verify(secretBackend, Mockito.times(1)).deleteDropboxSecret(dropboxSecretDeleteRequest);
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testDeleteDropboxSecret_CreateThrowsException() {
+        SecretServiceHandler secretServiceHandler = Mockito.spy(new SecretServiceHandler());
+        DropboxSecretDeleteRequest dropboxSecretDeleteRequest = Mockito.mock(DropboxSecretDeleteRequest.class);
+        StreamObserver<Empty> streamObserver = Mockito.mock(StreamObserver.class);
+        SecretBackend secretBackend = Mockito.mock(SecretBackend.class);
+
+        try {
+            Mockito.when(secretBackend.deleteDropboxSecret(dropboxSecretDeleteRequest)).thenThrow(new Exception());
+            Mockito.doReturn(secretBackend).when(secretServiceHandler).getBackend();
+
+            secretServiceHandler.deleteDropboxSecret(dropboxSecretDeleteRequest, streamObserver);
+
+            Mockito.verify(secretBackend, Mockito.times(1)).deleteDropboxSecret(dropboxSecretDeleteRequest);
+            Mockito.verify(streamObserver, Mockito.times(1)).onError(Mockito.any(StatusRuntimeException.class));
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+}

--- a/services/secret-service/server/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/services/secret-service/server/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
Dependencies that were added:

junit5 jupiter-5.6.2 for mft-core, resource-service/server, secret-service/server
Mockito-core 3.3.3 for mft-core, resource-service/server, secret-service/server
MockMaker mockito plugin for mocking final classes added to source-service/server, secret-service/server
Dependencies for other transports IN TEST SCOPE had to be added for the core module for writing tests for ConnectorResolver and MetadataCollectorResolver

Tests:
TestConnectorResolver for ConnectorResolver.java - 25 test cases
TestFileBasedResourceBackend for FileBasedResourceBackend - 16 test cases
TestFileBasedSecretBackend for FileBasedSecretBackend - 12 test cases
TestMetadataCollectorResolver for MetadataCollectorResolver - 9 test cases
TestResourceServiceHandler for ResourceServiceHandler - 80 test cases
TestSecretServiceHandler for SecretServiceHandler - 52 test cases
TestSQLResourceBackend for SQLResourceBackend - 13 test cases

Total - 207 unit tests

Since none of the classes had any unit tests, a lot of tests had to be written for handling as many edge cases as possible for all the transports.
Tests were written for all the transports except for FTP and GDrive since they're not yet merged to airavata-mft.

I've made sure to refactor code as less as possible.