### PR TITLE
Log exception when SSH session creation fails

### DIFF
--- a/transport/scp-transport/src/main/java/org/apache/airavata/mft/transport/scp/SCPTransportUtil.java
+++ b/transport/scp-transport/src/main/java/org/apache/airavata/mft/transport/scp/SCPTransportUtil.java
@@ -45,7 +45,9 @@ public class SCPTransportUtil {
 
             return session;
         } catch (JSchException e) {
-            throw new Exception("Failed to create a ssh session for " + user + "@" + host + ":" + port, e);
+            String message = "Failed to create a ssh session for " + user + "@" + host + ":" + port;
+            logger.error(message, e);
+            throw new Exception(message, e);
         }
     }
 }


### PR DESCRIPTION
For #33. This logs the exception to help track down errors when they occur.