### PR TITLE
getDirectoryResourceMetadata-filesize

### DIFF
--- a/transport/scp-transport/src/main/java/org/apache/airavata/mft/transport/scp/SCPMetadataCollector.java
+++ b/transport/scp-transport/src/main/java/org/apache/airavata/mft/transport/scp/SCPMetadataCollector.java
@@ -174,7 +174,8 @@ public class SCPMetadataCollector implements MetadataCollector {
                                         .withFriendlyName(rri.getName())
                                         .withResourcePath(rri.getPath())
                                         .withCreatedTime(rri.getAttributes().getAtime())
-                                        .withUpdateTime(rri.getAttributes().getMtime());
+                                        .withUpdateTime(rri.getAttributes().getMtime())
+                                        .withResourceSize(rri.getAttributes().getSize());
 
                         dirMetadataBuilder = dirMetadataBuilder.withFile(childFileBuilder.build());
                     }


### PR DESCRIPTION
Adds the file size to the FileResourceMetadata instances returned by getDirectoryResourceMetadata.