### PR TITLE
Update Python stub generation docs to include CredCommon.proto

### DIFF
--- a/examples/src/main/python/readme.md
+++ b/examples/src/main/python/readme.md
@@ -7,4 +7,5 @@ mkdir -p google/api
 curl https://raw.githubusercontent.com/googleapis/googleapis/master/google/api/annotations.proto > google/api/annotations.proto     
 curl https://raw.githubusercontent.com/googleapis/googleapis/master/google/api/http.proto > google/api/http.proto
 
-python -m grpc_tools.protoc -I. --python_out=. --grpc_python_out=. --proto_path=../../../../api/stub/src/main/proto/ MFTApi.proto 
+python -m grpc_tools.protoc -I. --python_out=. --grpc_python_out=. --proto_path=../../../../common/mft-common-proto/src/main/proto/ CredCommon.proto
+python -m grpc_tools.protoc -I. --python_out=. --grpc_python_out=. --proto_path=../../../../api/stub/src/main/proto/ --proto_path=../../../../common/mft-common-proto/src/main/proto/ MFTApi.proto


### PR DESCRIPTION
MFTApi.proto depends on CredCommon.proto, so the Python stub generation code needs to be similarly updated. This change generates the stubs for CredCommon.proto and then also includes CredCommon.proto on the proto_path when generating the MFTApi.proto stubs.