### PR TITLE
Fix sessionToken max length

### DIFF
--- a/services/secret-service/server/src/main/java/org/apache/airavata/mft/secret/server/backend/sql/entity/S3SecretEntity.java
+++ b/services/secret-service/server/src/main/java/org/apache/airavata/mft/secret/server/backend/sql/entity/S3SecretEntity.java
@@ -22,7 +22,7 @@ public class S3SecretEntity {
     @Column(name = "SECRET_KEY")
     private String secretKey;
 
-    @Column(name = "SESSION_TOKEN")
+    @Column(name = "SESSION_TOKEN", length = 512)
     private String sessionToken;
 
     public String getSecretId() {


### PR DESCRIPTION
I was not able to create a S3 resource with sessionToken.
The limitation was on the sessionToken column length accordig to the logs : 
```
2022-09-28 15:03:25,043 [grpc-default-executor-7] ERROR org.hibernate.engine.jdbc.spi.SqlExceptionHelper {} - Value too long for column "SESSION_TOKEN VARCHAR(255)": "'FwoGZXIvYXdzEIj//////////wEaDKcgpgGGF6VtPcgCwiLdAf5Zmg9MTSgp7IaDPsXbJcz9aOR8olV0kaFQMuV7sRv+y7/cnYe7637dnn1x1D3NwpoEQgP19NP13Mr... (416)"; SQL statement:
insert into s3secret_entity (access_key, secret_key, session_token, secret_id) values (?, ?, ?, ?) [22001-191]
```