### PR TITLE
guava 31.1-jre added

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,7 @@
         <commons.io.version>2.6</commons.io.version>
         <apache.http.client.version>4.5.13</apache.http.client.version>
         <aws.sdk.version>1.12.372</aws.sdk.version>
+        <guava.version>31.1-jre</guava.version>
     </properties>
 
 </project>

--- a/standalone-service/pom.xml
+++ b/standalone-service/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>31.1-jre</version>
+            <version>${guava.version}</version>
         </dependency>
         <dependency>
             <groupId>io.github.lognet</groupId>

--- a/standalone-service/pom.xml
+++ b/standalone-service/pom.xml
@@ -34,6 +34,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>31.1-jre</version>
+        </dependency>
+        <dependency>
             <groupId>io.github.lognet</groupId>
             <artifactId>grpc-spring-boot-starter</artifactId>
             <version>${grpc.spring.boot}</version>


### PR DESCRIPTION
It fixes the guava version for jre in standalone execution and fixes the bug https://github.com/apache/airavata-mft/issues/84
