### PR TITLE
Local transport v2 and other fixes

### DIFF
--- a/core/src/main/java/org/apache/airavata/mft/core/ConnectorResolver.java
+++ b/core/src/main/java/org/apache/airavata/mft/core/ConnectorResolver.java
@@ -45,9 +45,9 @@ public final class ConnectorResolver {
             case "GCS":
                 className = "org.apache.airavata.mft.transport.gcp.GCSIncomingStreamingConnector";
                 break;
-//            case "LOCAL":
-//                className = "org.apache.airavata.mft.transport.local.LocalIncomingStreamingConnector";
-//                break;
+            case "LOCAL":
+                className = "org.apache.airavata.mft.transport.local.LocalIncomingStreamingConnector";
+                break;
         }
 
         if (className != null) {

--- a/python-cli/mft_cli/airavata_mft_cli/config.py
+++ b/python-cli/mft_cli/airavata_mft_cli/config.py
@@ -1,0 +1,7 @@
+transfer_api_port = 7004
+transfer_api_secured = False
+resource_service_host = "localhost"
+resource_service_port = 7002
+resource_service_secured = False
+secret_service_host = "localhost"
+secret_service_port = 7003

--- a/python-cli/mft_cli/airavata_mft_cli/operations.py
+++ b/python-cli/mft_cli/airavata_mft_cli/operations.py
@@ -23,15 +23,18 @@ from airavata_mft_sdk import MFTTransferApi_pb2
 from rich.console import Console
 from rich.table import Table
 import time
+import sys
+sys.path.append('.')
+from . import config as configcli
 
 def fetch_storage_and_secret_ids(storage_name):
-  client = mft_client.MFTClient(transfer_api_port = 7003,
-                                transfer_api_secured = False,
-                                resource_service_host = "localhost",
-                                resource_service_port = 7003,
-                                resource_service_secured = False,
-                                secret_service_host = "localhost",
-                                secret_service_port = 7003)
+  client = mft_client.MFTClient(transfer_api_port = configcli.transfer_api_port,
+                                transfer_api_secured = configcli.transfer_api_secured,
+                                resource_service_host = configcli.resource_service_host,
+                                resource_service_port = configcli.resource_service_port,
+                                resource_service_secured = configcli.resource_service_secured,
+                                secret_service_host = configcli.secret_service_host,
+                                secret_service_port = configcli.secret_service_port)
   search_req = StorageCommon_pb2.StorageSearchRequest(storageName=storage_name)
   storages = client.common_api.searchStorages(search_req)
 
@@ -68,13 +71,13 @@ def get_resource_metadata(storage_path, recursive_search = False):
                                                                 resourcePath = resource_path)
   resource_medata_req = MFTTransferApi_pb2.FetchResourceMetadataRequest(idRequest = id_req)
 
-  client = mft_client.MFTClient(transfer_api_port = 7003,
-                                transfer_api_secured = False,
-                                resource_service_host = "localhost",
-                                resource_service_port = 7003,
-                                resource_service_secured = False,
-                                secret_service_host = "localhost",
-                                secret_service_port = 7003)
+  client = mft_client.MFTClient(transfer_api_port = configcli.transfer_api_port,
+                                transfer_api_secured = configcli.transfer_api_secured,
+                                resource_service_host = configcli.resource_service_host,
+                                resource_service_port = configcli.resource_service_port,
+                                resource_service_secured = configcli.resource_service_secured,
+                                secret_service_host = configcli.secret_service_host,
+                                secret_service_port = configcli.secret_service_port)
 
   metadata_resp = client.transfer_api.resourceMetadata(resource_medata_req)
   return metadata_resp
@@ -167,18 +170,18 @@ def copy(source, destination):
                           " files to be transferred. Total volume is " + str(total_volume)
                           + " bytes. Do you want to start the transfer? ", True)
 
-  client = mft_client.MFTClient(transfer_api_port = 7003,
-                                transfer_api_secured = False,
-                                resource_service_host = "localhost",
-                                resource_service_port = 7003,
-                                resource_service_secured = False,
-                                secret_service_host = "localhost",
-                                secret_service_port = 7003)
+  if not confirm:
+      raise typer.Abort()
+
+  client = mft_client.MFTClient(transfer_api_port = configcli.transfer_api_port,
+                                transfer_api_secured = configcli.transfer_api_secured,
+                                resource_service_host = configcli.resource_service_host,
+                                resource_service_port = configcli.resource_service_port,
+                                resource_service_secured = configcli.resource_service_secured,
+                                secret_service_host = configcli.secret_service_host,
+                                secret_service_port = configcli.secret_service_port)
 
   transfer_resp = client.transfer_api.submitTransfer(transfer_request)
-
-  if not confirm:
-    raise typer.Abort()
 
   transfer_id = transfer_resp.transferId
 

--- a/python-cli/mft_cli/airavata_mft_cli/storage/__init__.py
+++ b/python-cli/mft_cli/airavata_mft_cli/storage/__init__.py
@@ -27,6 +27,9 @@ from airavata_mft_sdk import mft_client
 from airavata_mft_sdk.common import StorageCommon_pb2
 from rich.console import Console
 from rich.table import Table
+import sys
+sys.path.append('../airavata_mft_cli')
+from airavata_mft_cli import config as configcli
 
 app = typer.Typer()
 
@@ -49,13 +52,13 @@ def add_storage():
 
 @app.command("list")
 def list_storage():
-    client = mft_client.MFTClient(transfer_api_port = 7003,
-                                  transfer_api_secured = False,
-                                  resource_service_host = "localhost",
-                                  resource_service_port = 7003,
-                                  resource_service_secured = False,
-                                  secret_service_host = "localhost",
-                                  secret_service_port = 7003)
+    client = mft_client.MFTClient(transfer_api_port = configcli.transfer_api_port,
+                                  transfer_api_secured = configcli.transfer_api_secured,
+                                  resource_service_host = configcli.resource_service_host,
+                                  resource_service_port = configcli.resource_service_port,
+                                  resource_service_secured = configcli.resource_service_secured,
+                                  secret_service_host = configcli.secret_service_host,
+                                  secret_service_port = configcli.secret_service_port)
     list_req = StorageCommon_pb2.StorageListRequest()
     list_response = client.common_api.listStorages(list_req)
 

--- a/python-cli/mft_cli/airavata_mft_cli/storage/azure.py
+++ b/python-cli/mft_cli/airavata_mft_cli/storage/azure.py
@@ -25,6 +25,9 @@ from airavata_mft_sdk.azure import AzureStorage_pb2
 from airavata_mft_sdk import MFTTransferApi_pb2
 from airavata_mft_sdk import MFTAgentStubs_pb2
 from airavata_mft_sdk.common import StorageCommon_pb2
+import sys
+sys.path.append('../airavata_mft_cli')
+from airavata_mft_cli import config as configcli
 
 def handle_add_storage():
 
@@ -34,13 +37,13 @@ def handle_add_storage():
     if index == 1: # Manual configuration
         connection_string = typer.prompt("Connection String")
 
-    client = mft_client.MFTClient(transfer_api_port = 7003,
-                                  transfer_api_secured = False,
-                                  resource_service_host = "localhost",
-                                  resource_service_port = 7003,
-                                  resource_service_secured = False,
-                                  secret_service_host = "localhost",
-                                  secret_service_port = 7003)
+    client = mft_client.MFTClient(transfer_api_port = configcli.transfer_api_port,
+                                  transfer_api_secured = configcli.transfer_api_secured,
+                                  resource_service_host = configcli.resource_service_host,
+                                  resource_service_port = configcli.resource_service_port,
+                                  resource_service_secured = configcli.resource_service_secured,
+                                  secret_service_host = configcli.secret_service_host,
+                                  secret_service_port = configcli.secret_service_port)
 
     azure_secret = AzureCredential_pb2.AzureSecret(connectionString = connection_string)
     secret_wrapper = MFTAgentStubs_pb2.SecretWrapper(azure=azure_secret)

--- a/python-cli/mft_cli/airavata_mft_cli/storage/gcs.py
+++ b/python-cli/mft_cli/airavata_mft_cli/storage/gcs.py
@@ -30,6 +30,9 @@ import os
 import base64
 import google.auth
 import googleapiclient.discovery
+import sys
+sys.path.append('../airavata_mft_cli')
+from airavata_mft_cli import config as configcli
 
 gcs_key_path = '.mft/keys/gcs/service_account_key.json'
 
@@ -115,13 +118,13 @@ def handle_add_storage():
                 print("No credential found in ~/" + gcs_key_path + " file")
                 exit()
 
-    client = mft_client.MFTClient(transfer_api_port = 7003,
-                                  transfer_api_secured = False,
-                                  resource_service_host = "localhost",
-                                  resource_service_port = 7003,
-                                  resource_service_secured = False,
-                                  secret_service_host = "localhost",
-                                  secret_service_port = 7003)
+    client = mft_client.MFTClient(transfer_api_port = configcli.transfer_api_port,
+                                  transfer_api_secured = configcli.transfer_api_secured,
+                                  resource_service_host = configcli.resource_service_host,
+                                  resource_service_port = configcli.resource_service_port,
+                                  resource_service_secured = configcli.resource_service_secured,
+                                  secret_service_host = configcli.secret_service_host,
+                                  secret_service_port = configcli.secret_service_port)
 
     gcs_secret = GCSCredential_pb2.GCSSecret(clientEmail=client_email, privateKey=client_secret, projectId=project_id)
     secret_wrapper = MFTAgentStubs_pb2.SecretWrapper(gcs=gcs_secret)

--- a/python-cli/mft_cli/airavata_mft_cli/storage/local.py
+++ b/python-cli/mft_cli/airavata_mft_cli/storage/local.py
@@ -20,6 +20,9 @@ from rich import print
 import typer
 from airavata_mft_sdk import mft_client
 from airavata_mft_sdk.local import LocalStorage_pb2
+import sys
+sys.path.append('../airavata_mft_cli')
+from airavata_mft_cli import config as configcli
 
 
 def handle_add_storage():
@@ -27,13 +30,13 @@ def handle_add_storage():
     agent_id = typer.prompt("Agent identifier")
     name = typer.prompt("Storage name",agent_id)
 
-    client = mft_client.MFTClient(transfer_api_port = 7003,
-                                  transfer_api_secured = False,
-                                  resource_service_host = "localhost",
-                                  resource_service_port = 7003,
-                                  resource_service_secured = False,
-                                  secret_service_host = "localhost",
-                                  secret_service_port = 7003)
+    client = mft_client.MFTClient(transfer_api_port = configcli.transfer_api_port,
+                                  transfer_api_secured = configcli.transfer_api_secured,
+                                  resource_service_host = configcli.resource_service_host,
+                                  resource_service_port = configcli.resource_service_port,
+                                  resource_service_secured = configcli.resource_service_secured,
+                                  secret_service_host = configcli.secret_service_host,
+                                  secret_service_port = configcli.secret_service_port)
 
     local_storage_create_req = LocalStorage_pb2.LocalStorageCreateRequest(
         agentId = agent_id, name = name)

--- a/python-cli/mft_cli/airavata_mft_cli/storage/s3.py
+++ b/python-cli/mft_cli/airavata_mft_cli/storage/s3.py
@@ -27,6 +27,9 @@ from airavata_mft_sdk import MFTAgentStubs_pb2
 from airavata_mft_sdk.common import StorageCommon_pb2
 import configparser
 import os
+import sys
+sys.path.append('../airavata_mft_cli')
+from airavata_mft_cli import config as configcli
 
 def handle_add_storage():
 
@@ -79,13 +82,13 @@ def handle_add_storage():
         region, index = pick(aws_regions, "Select the AWS Region", indicator="=>")
         endpoint = "https://s3." + region + ".amazonaws.com"
 
-    client = mft_client.MFTClient(transfer_api_port = 7003,
-                                  transfer_api_secured = False,
-                                  resource_service_host = "localhost",
-                                  resource_service_port = 7003,
-                                  resource_service_secured = False,
-                                  secret_service_host = "localhost",
-                                  secret_service_port = 7003)
+    client = mft_client.MFTClient(transfer_api_port = configcli.transfer_api_port,
+                                  transfer_api_secured = configcli.transfer_api_secured,
+                                  resource_service_host = configcli.resource_service_host,
+                                  resource_service_port = configcli.resource_service_port,
+                                  resource_service_secured = configcli.resource_service_secured,
+                                  secret_service_host = configcli.secret_service_host,
+                                  secret_service_port = configcli.secret_service_port)
 
     s3_secret = S3Credential_pb2.S3Secret(accessKey=client_id, secretKey=client_secret, sessionToken = session_token)
     secret_wrapper = MFTAgentStubs_pb2.SecretWrapper(s3=s3_secret)

--- a/python-cli/mft_cli/airavata_mft_cli/storage/swift.py
+++ b/python-cli/mft_cli/airavata_mft_cli/storage/swift.py
@@ -23,6 +23,9 @@ from airavata_mft_sdk import mft_client
 from airavata_mft_sdk.swift import SwiftCredential_pb2
 from airavata_mft_sdk.swift import SwiftStorage_pb2
 from airavata_mft_sdk.common import StorageCommon_pb2
+import sys
+sys.path.append('../airavata_mft_cli')
+from airavata_mft_cli import config as configcli
 
 def handle_add_storage():
 
@@ -56,13 +59,13 @@ def handle_add_storage():
 
     storage_name = typer.prompt("Name of the storage ", container)
 
-    client = mft_client.MFTClient(transfer_api_port = 7003,
-                                  transfer_api_secured = False,
-                                  resource_service_host = "localhost",
-                                  resource_service_port = 7003,
-                                  resource_service_secured = False,
-                                  secret_service_host = "localhost",
-                                  secret_service_port = 7003)
+    client = mft_client.MFTClient(transfer_api_port = configcli.transfer_api_port,
+                                  transfer_api_secured = configcli.transfer_api_secured,
+                                  resource_service_host = configcli.resource_service_host,
+                                  resource_service_port = configcli.resource_service_port,
+                                  resource_service_secured = configcli.resource_service_secured,
+                                  secret_service_host = configcli.secret_service_host,
+                                  secret_service_port = configcli.secret_service_port)
 
 
     swift_storage_create_req = SwiftStorage_pb2.SwiftStorageCreateRequest(region=region_name,

--- a/scripts/start-consul.sh
+++ b/scripts/start-consul.sh
@@ -27,7 +27,7 @@ case $1 in
             curl -O https://releases.hashicorp.com/consul/1.7.1/consul_1.7.1_darwin_amd64.zip
             unzip -o consul_1.7.1_darwin_amd64.zip -d ../airavata-mft/consul
             rm consul_1.7.1_darwin_amd64.zip
-            nohup ../airavata-mft/consul/consul agent -dev > $LOG_FILE 2>&1 &
+            nohup ../airavata-mft/consul/consul agent -dev -client 0.0.0.0 > $LOG_FILE 2>&1 &
             echo $! > $PID_PATH_NAME
             echo "Consul started"
         else

--- a/transport/local-transport/src/main/java/org/apache/airavata/mft/transport/local/LocalIncomingChunkedConnector.java
+++ b/transport/local-transport/src/main/java/org/apache/airavata/mft/transport/local/LocalIncomingChunkedConnector.java
@@ -21,22 +21,24 @@ package org.apache.airavata.mft.transport.local;
 import org.apache.airavata.mft.core.api.ConnectorConfig;
 import org.apache.airavata.mft.core.api.IncomingChunkedConnector;
 
-import java.io.InputStream;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.File;
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class LocalIncomingChunkedConnector implements IncomingChunkedConnector {
 
     private String resourcePath;
+    private long resourceSize;
 
     private static final Logger logger = LoggerFactory.getLogger(LocalIncomingChunkedConnector.class);
 
     @Override
     public void init(ConnectorConfig connectorConfig) throws Exception {
         this.resourcePath = connectorConfig.getResourcePath();
+        this.resourceSize = connectorConfig.getMetadata().getFile().getResourceSize();
     }
 
     @Override
@@ -53,45 +55,40 @@ public class LocalIncomingChunkedConnector implements IncomingChunkedConnector {
     @Override
     public void downloadChunk(int chunkId, long startByte, long endByte, String downloadFile) throws Exception {
 
-        FileInputStream from = new FileInputStream(new File(this.resourcePath));
-        FileOutputStream to = new FileOutputStream(new File(downloadFile));
+        logger.info("Downloading chunk {} with start byte {} and end byte {} to file {} from resource path {}",
+                chunkId, startByte, endByte, downloadFile, this.resourcePath);
 
-        final int buffLen = 1024;
+//        #use this code on a DMA enabled device
+//        if (resourceSize <= endByte - startByte) {
+//            Files.copy(Path.of(this.resourcePath), Path.of(downloadFile));
+//        } else {
+//            try (FileInputStream from = new FileInputStream(this.resourcePath);
+//                 FileOutputStream to = new FileOutputStream(downloadFile)) {
+//                from.getChannel().transferTo(startByte, endByte - startByte, to.getChannel());
+//            } catch (Exception e) {
+//                logger.error("Unexpected error occurred while downloading chunk {} to file {} from resource path {}",
+//                        chunkId, downloadFile, this.resourcePath, e);
+//                throw e;
+//            }
+//        }
 
-        byte[] buf = new byte[buffLen];
-
-        from.skip(startByte);
-
-        long fileSize = endByte - startByte + 1;
-
-        while (true) {
-            int bufSize = 0;
-
-            if (buffLen < fileSize) {
-                bufSize = buffLen;
-            } else {
-                bufSize = (int) fileSize;
+        int buffLen = 1024 * 1024 * 16;
+        try (BufferedInputStream bis = new BufferedInputStream(new FileInputStream(this.resourcePath),buffLen);
+             BufferedOutputStream bos = new BufferedOutputStream(new FileOutputStream(downloadFile))) {
+            byte[] buffer = new byte[buffLen];
+            int read = 0;
+            long totalRead = bis.skip(startByte);
+            while ((read = bis.read(buffer,0,Math.min(buffLen, (int) (endByte - totalRead )))) > 0) {
+                bos.write(buffer, 0, read);
+                totalRead += read;
             }
-
-            bufSize = (int) from.read(buf, 0, bufSize);
-
-            if (bufSize < 0) {
-                break;
-            }
-
-            to.write(buf, 0, bufSize);
-            to.flush();
-
-            fileSize -= bufSize;
-
-            if (fileSize == 0L) {
-                break;
-            }
+            bis.close();
+            bos.close();
+        } catch (Exception e) {
+            logger.error("Unexpected error occurred while downloading chunk {} to file {} from resource path {}",
+                        chunkId, downloadFile, this.resourcePath, e);
+                throw e;
         }
-
-        from.close();
-        to.close();
-
     }
 
     @Override
@@ -101,6 +98,6 @@ public class LocalIncomingChunkedConnector implements IncomingChunkedConnector {
 
         from.skip(startByte);
 
-        return from;
+        return new BufferedInputStream(from, Math.min(16 * 1024 * 1024,(int) (endByte - startByte)));
     }
 }

--- a/transport/local-transport/src/main/java/org/apache/airavata/mft/transport/local/LocalIncomingStreamingConnector.java
+++ b/transport/local-transport/src/main/java/org/apache/airavata/mft/transport/local/LocalIncomingStreamingConnector.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.airavata.mft.transport.local;
+
+
+import org.apache.airavata.mft.core.api.ConnectorConfig;
+import org.apache.airavata.mft.core.api.IncomingStreamingConnector;
+
+import java.io.InputStream;
+import java.io.FileInputStream;
+import java.io.File;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class LocalIncomingStreamingConnector implements IncomingStreamingConnector{
+
+    private String resourcePath;
+
+    private static final Logger logger = LoggerFactory.getLogger(LocalIncomingStreamingConnector.class);
+
+    @Override
+    public void init(ConnectorConfig connectorConfig) throws Exception {
+        this.resourcePath = connectorConfig.getResourcePath();
+    }
+
+    @Override
+    public void complete() throws Exception {
+        logger.info("File {} successfully received", this.resourcePath);
+    }
+
+    @Override
+    public void failed() throws Exception {
+        logger.error("Failed while receiving file {}", this.resourcePath);
+    }
+
+    @Override
+    public InputStream fetchInputStream() throws Exception {
+        InputStream from = new FileInputStream(new File(this.resourcePath));
+
+        return from;
+    }
+}


### PR DESCRIPTION
This PR has 5 updates as follows:

- [gRPC ports config](https://github.com/apache/airavata-mft/commit/12dc6e7b2b50e3b70927403bc8c91446ce5df9b6)
  - Added config file to update ports for transfer_api, resource service and secret service
- [Local incoming streamer added](https://github.com/apache/airavata-mft/commit/a19b4201a4dbfd216e26fc6f021b3d183e57bbc9)
  - Implemented incoming streaming connector for local transport
- [Local incoming chunked update](https://github.com/apache/airavata-mft/commit/dedc153d90a9e9c1f1e0ad42f70d627f27ffff17)
  - Updated local incoming chunked connector code for efficiency
- [S3 Outgoing bufferStreaming update](https://github.com/apache/airavata-mft/commit/3664e4e9db5548cc14c7ce15f29d81b8ce49ea4d)
  - Updated from file to use Buffered Streaming
- [consul update to accept all](https://github.com/apache/airavata-mft/commit/58e7f52f5704375f6d9beacd04ef4ad3cb274906)
  - Allowed to consul to connect with all ip addresses