### PR TITLE
grpcio grpcio tools issue 104

### DIFF
--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -17,5 +17,5 @@
 # under the License.
 
 [build-system]
-requires = ["setuptools>=42", "grpcio==1.46.3", "grpcio-tools==1.46.3"]
+requires = ["setuptools>=42"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Here, as per the suggestion of @machristie,  I removed grpcio and grpcio-tools from a Python list with the variable name "requires" from https://github.com/apache/airavata-mft/blob/master/python-sdk/pyproject.toml so that the airavata-mft will be able to install successfully with python3.11.

EDIT: This addresses the issue: https://github.com/apache/airavata-mft/issues/104

