### PR TITLE
grpcio_tools_issue#104

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!--
+ <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information

--- a/python-cli/mft_cli/pyproject.toml
+++ b/python-cli/mft_cli/pyproject.toml
@@ -38,8 +38,6 @@ mft = "airavata_mft_cli.main:app"
 python = "^3.10"
 typer = {extras = ["all"], version = "^0.7.0"}
 pick = {version= "2.2.0"}
-grpcio= [{version="1.46.3", markers = "platform_machine != 'arm64'"},{version="1.47.0rc1", markers = "platform_machine == 'arm64'"}]
-grpcio-tools = [{version="1.46.3", markers = "platform_machine != 'arm64'"},{version="1.47.0rc1", markers = "platform_machine == 'arm64'"}]
 airavata-mft-sdk = "0.0.1a34"
 pandas = "^2.0.3"
 


### PR DESCRIPTION
Issue: #104 and #106 and #122

Fixes: https://github.com/apache/airavata-mft/issues/104 and https://github.com/apache/airavata-mft/issues/122

Motivation
Specific versions of grpcio and grpcio-tools were reverting back to previous versions while installing airavata-mft with Python3.11

Modifications

grpcio= [{version="1.46.3", markers = "platform_machine != 'arm64'"},{version="1.47.0rc1", markers = "platform_machine == 'arm64'"}]
grpcio-tools = [{version="1.46.3", markers = "platform_machine != 'arm64'"},{version="1.47.0rc1", markers = "platform_machine == 'arm64'"}]

Both grpcio and grpcio-tools are removed now.

Documentation
If a feature is not applicable for documentation, explain why?
This is not applicable for documentation because the core functionality remains same.